### PR TITLE
Create checksums in ISO

### DIFF
--- a/helpers/create-iso
+++ b/helpers/create-iso
@@ -89,6 +89,15 @@ AUTORUN_INF
   local squash_asc="${DIR_IMAGES_ENDLESS}/${EIB_OUTVERSION}.squash.asc"
   sign_file "$squash" "$squash_asc"
 
+  # Generate checksums so the files can be validated without GPG.
+  local img_checksum="${DIR_IMAGES_ENDLESS}/${EIB_OUTVERSION}.img.sha256"
+  local boot_zip_checksum="${DIR_IMAGES_ENDLESS}/${EIB_OUTVERSION}.boot.zip.sha256"
+  local squash_checksum="${DIR_IMAGES_ENDLESS}/${EIB_OUTVERSION}.squash.sha256"
+  sha256sum "$img" | awk '{printf "%s", $1}' > "$img_checksum" &
+  sha256sum "$boot_zip" | awk '{printf "%s", $1}' > "$boot_zip_checksum" &
+  sha256sum "$squash" | awk '{printf "%s", $1}' > "$squash_checksum" &
+  wait
+
   # Construct ESP
   unzip -q -d "${DIR_EFI}" "${boot_zip}" "EFI/*"
   local DIR_EFI_SIZE=$(du -s "${DIR_EFI}" | cut -f1)


### PR DESCRIPTION
The idea here is to create `.sha256` files in the ISO so that eos-installer can use them for verification when signatures aren't available. See endlessm/eos-installer#91.

I'm not sure if it would be better to have a `SHA256SUMS` file as would be normally produced by `sha256sum` but it seemed a little odd because the image file is actually embedded in the squashfs image, so you couldn't actually do something like run `sha256sum -c`.

https://phabricator.endlessm.com/T31304