### PR TITLE
Remove host dpkg-dev requirement

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            dpkg-dev \
             gpg \
             gpgv \
             python3-pip

--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ Known to work on Debian Jessie (8) and Ubuntu Trusty (14.04). Required
 packages:
 
  * mmdebstrap
- * dpkg-dev (for dpkg-architecture)
  * e2fsprogs (for chattr)
  * git
  * gnupg

--- a/README.md
+++ b/README.md
@@ -67,12 +67,9 @@ build log to the image server.
 Setup
 =====
 
-Known to work on Debian Jessie (8) and Ubuntu Trusty (14.04). Required
-packages:
+Known to work on Debian Buster (10) and newer. Required packages:
 
  * mmdebstrap
- * e2fsprogs (for chattr)
- * git
  * gnupg
  * python3
 

--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -25,8 +25,6 @@
 
 # Generated attributes
 #build_version =
-#deb_host_gnu_cpu =
-#deb_host_multiarch =
 
 # Paths managed by the builder
 #srcdir = /path/to/eos-image-builder
@@ -74,6 +72,7 @@ packages_add =
   cpio
   curl
   dbus-user-session
+  dpkg-dev
   endless-ca-cert
   eos-keyring
   eos-tech-support

--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -363,7 +363,9 @@ enable = true
 
 # Flatpak architecture. This is different from debian style arch used
 # for the build. E.g, the build uses amd64 while flatpak uses x86_64.
-arch = ${build:deb_host_gnu_cpu}
+# Normally this is not required as the default flatpak architecture will
+# be correct.
+arch =
 
 # Locales to use when pulling runtimes
 locales_add = ar be bn en es fr hu id ko pt ro ru sr uk zh

--- a/lib/eibflatpak.py
+++ b/lib/eibflatpak.py
@@ -503,9 +503,11 @@ class FlatpakManager(object):
         self.install_refs = None
 
         # Get architecture from generic flatpak section, falling back to
-        # default arch for host
-        self.arch = self.config.get('flatpak', 'arch',
-                                    fallback=Flatpak.get_default_arch())
+        # default arch for host. The config default is an empty string,
+        # so the direct fallback mechanism doesn't work.
+        self.arch = self.config.get('flatpak', 'arch', fallback=None)
+        if not self.arch:
+            self.arch = Flatpak.get_default_arch()
         logger.info('Using flatpak arch %s', self.arch)
 
         # Get locales configuration from generic flatpak section

--- a/run-build
+++ b/run-build
@@ -211,7 +211,6 @@ class ImageBuilder(object):
         'product', 'branch', 'arch', 'platform', 'personality',
         'dry_run', 'series', 'srcdir', 'cachedir',
         'sysconfdir', 'build_version',
-        'deb_host_gnu_cpu', 'deb_host_multiarch',
         'use_production_ostree',
     ]
     BOOLEAN_ATTRS = [
@@ -322,17 +321,6 @@ class ImageBuilder(object):
         self.cachedir = eib.CACHEDIR
         self.sysconfdir = eib.SYSCONFDIR
         self.build_version = datetime.datetime.utcnow().strftime('%y%m%d-%H%M%S')
-
-        # Pull in dpkg-architecture settings that are needed for the
-        # installation of flatpak bundles.
-        gnu_cpu = subprocess.check_output(['dpkg-architecture',
-                                           '-a' + self.arch,
-                                           '-qDEB_HOST_GNU_CPU'])
-        self.deb_host_gnu_cpu = gnu_cpu.decode().strip()
-        multiarch = subprocess.check_output(['dpkg-architecture',
-                                             '-a' + self.arch,
-                                             '-qDEB_HOST_MULTIARCH'])
-        self.deb_host_multiarch = multiarch.decode().strip()
 
     def _get_config_paths(self, dir_path, dir_ns):
         config_files = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,8 +43,6 @@ def builder_config(config):
         'cachedir': eib.CACHEDIR,
         'sysconfdir': eib.SYSCONFDIR,
         'build_version': '200101-000000',
-        'deb_host_gnu_cpu': 'x86_64',
-        'deb_host_multiarch': 'x86_64-linux-gnu',
         'use_production_ostree': 'false'
     })
 

--- a/tests/test_image_builder.py
+++ b/tests/test_image_builder.py
@@ -84,19 +84,6 @@ def test_bad_arch(make_builder):
         make_builder(arch='notanarch')
 
 
-@pytest.mark.parametrize('arch,expected_gnu_cpu,expected_multiarch', [
-    ('amd64', 'x86_64', 'x86_64-linux-gnu'),
-    ('arm64', 'aarch64', 'aarch64-linux-gnu'),
-    ('i386', 'i686', 'i386-linux-gnu'),
-    ('armhf', 'arm', 'arm-linux-gnueabihf'),
-])
-def test_arch_details(make_builder, arch, expected_gnu_cpu,
-                      expected_multiarch):
-    builder = make_builder(arch=arch)
-    assert builder.deb_host_gnu_cpu == expected_gnu_cpu
-    assert builder.deb_host_multiarch == expected_multiarch
-
-
 # Build test variants. This is ideally the same as the release image
 # variants. Configurations with master and the latest stable branch are
 # tested.


### PR DESCRIPTION
Stop gathering architecture details during setup with `dpkg-architecture` so that the dpkg-dev package isn't needed on the host. Instead, dpkg-dev is included in the buildroot so that `dpkg-architecture` is available if needed.

https://phabricator.endlessm.com/T31702