### PR TITLE
Create per-file checksums

### DIFF
--- a/helpers/create-iso
+++ b/helpers/create-iso
@@ -13,6 +13,10 @@ create_iso() {
   shift
   local boot_zip=${1:?No boot.zip supplied to $FUNCNAME}
   shift
+  local img_csum=${1:?No image checksum supplied to $FUNCNAME}
+  shift
+  local boot_zip_csum=${1:?No boot.zip checksum supplied to $FUNCNAME}
+  shift
 
   local ISO_TMPDIR="$EIB_TMPDIR/iso"
   local DIR_EFI="$ISO_TMPDIR/efi"
@@ -22,6 +26,9 @@ create_iso() {
   mkdir -p "$DIR_EFI" "$DIR_ESP" "$DIR_IMAGES_ENDLESS"
 
   ln "$boot_zip" "${DIR_IMAGES_ENDLESS}/$(basename "$boot_zip")"
+  ln "$img_csum" "${DIR_IMAGES_ENDLESS}/$(basename "$img_csum")"
+  ln "$boot_zip_csum" "${DIR_IMAGES_ENDLESS}/$(basename "$boot_zip_csum")"
+
   # Link img.asc, boot.zip.asc into ISO tree if they exist. During manual
   # testing, the GPG key may not be available in which case no signatures will
   # be generated -- allow that here.
@@ -87,7 +94,10 @@ AUTORUN_INF
   # generate split images.
 
   local squash_asc="${DIR_IMAGES_ENDLESS}/${EIB_OUTVERSION}.squash.asc"
-  sign_file "$squash" "$squash_asc"
+  local squash_csum="${DIR_IMAGES_ENDLESS}/${EIB_OUTVERSION}.squash.sha256"
+  sign_file "$squash" "$squash_asc" &
+  checksum_file "$squash" "$squash_csum" &
+  wait
 
   # Construct ESP
   unzip -q -d "${DIR_EFI}" "${boot_zip}" "EFI/*"
@@ -148,13 +158,16 @@ AUTORUN_INF
     fi
   fi
 
-  # Sign ISO
-  sign_file "${iso}"
+  # Sign and checksum ISO
+  sign_file "${iso}" &
+  checksum_file "${iso}" &
+  wait
 
   # Generate ISO manifest information
   local iso_name=$(basename "${iso}")
   local iso_compressed_size=$(stat -c "%s" "${iso}")
   local iso_signature=$(basename "${iso}.asc")
+  local iso_checksum=$(basename "${iso}.sha256")
 
   cat > "${EIB_MANIFESTDIR}"/iso.json <<EOF
 {
@@ -164,7 +177,8 @@ AUTORUN_INF
       "extracted_size": ${img_size},
       "compressed_size": ${iso_compressed_size},
       "compression_type": "iso+squashfs",
-      "signature": "${iso_signature}"
+      "signature": "${iso_signature}",
+      "checksum": "${iso_checksum}"
     }
   }
 }

--- a/helpers/create-usb-image
+++ b/helpers/create-usb-image
@@ -95,12 +95,12 @@ create_usb_image() {
 
   sign_file "${out_img}"
   local out_img_size=$(stat -c "%s" "${out_img}")
-  local out_img_signature=$(basename "${out_img}.asc")
 
   local out_zimg="${out_img}.${EIB_IMAGE_COMPRESSION}"
   eib_compress_image "${out_img}" "${out_zimg}"
   sign_file "${out_zimg}"
   local out_zimg_size=$(stat -c "%s" "${out_zimg}")
+  local out_zimg_signature=$(basename "${out_zimg}.asc")
 
   # Remove uncompressed image.
   rm -f "${out_img}"
@@ -114,7 +114,7 @@ create_usb_image() {
       "extracted_size": ${out_img_size},
       "compressed_size": ${out_zimg_size},
       "compression_type": "${EIB_IMAGE_COMPRESSION}",
-      "signature": "${out_img_signature}"
+      "signature": "${out_zimg_signature}"
     }
   }
 }

--- a/helpers/create-usb-image
+++ b/helpers/create-usb-image
@@ -42,13 +42,17 @@ create_usb_image() {
   shift
   local out_img=${1:?No target filename ${FUNCNAME}}
   shift
-  local src_img=${1:?No src_img supplied to ${FUNCNAME}}
+  local src_img=${1:?No source image supplied to ${FUNCNAME}}
   shift
   local boot_zip=${1:?No boot.zip supplied to ${FUNCNAME}}
   shift
-  local src_img_asc=${1:?No boot.zip supplied to ${FUNCNAME}}
+  local src_img_csum=${1:?No image checksum supplied to ${FUNCNAME}}
   shift
-  local boot_zip_asc=${1:?No boot.zip supplied to ${FUNCNAME}}
+  local boot_zip_csum=${1:?No boot.zip checksum supplied to ${FUNCNAME}}
+  shift
+  local src_img_asc=${1:?No image signature supplied to ${FUNCNAME}}
+  shift
+  local boot_zip_asc=${1:?No boot.zip signature supplied to ${FUNCNAME}}
   shift
 
   local src_img_name=$(basename "${src_img}")
@@ -57,11 +61,13 @@ create_usb_image() {
   local downloads_dir="${EIB_CONTENTDIR}/create-usb-image-downloads"
   mkdir -p "${downloads_dir}"
 
-  # eos-write-live-image expects to find img.asc, boot.zip, and boot.zip.asc
-  # in the same directory as $src_img, so create a temporary directory with
-  # all of these files.
+  # eos-write-live-image expects to find the image, boot.zip and
+  # associated signatures and checksums in the same directory, so create
+  # a temporary directory with all of these files.
   mkdir -p "${create_usb_image_tmp_dir}"
-  ln -sf "${src_img}" "${src_img_asc}" "${boot_zip}" "${boot_zip_asc}" -t "${create_usb_image_tmp_dir}"
+  ln -sf -t "${create_usb_image_tmp_dir}" \
+    "${src_img}" "${src_img_csum}" "${src_img_asc}" \
+    "${boot_zip}" "${boot_zip_csum}" "${boot_zip_asc}"
 
   # Copy Windows launcher
   download_file "${launcher_url}" "${downloads_dir}/Endless Launcher.exe"
@@ -93,14 +99,20 @@ create_usb_image() {
 
   cleanup_devices
 
-  sign_file "${out_img}"
+  sign_file "${out_img}" &
+  checksum_file "${out_img}" &
   local out_img_size=$(stat -c "%s" "${out_img}")
 
   local out_zimg="${out_img}.${EIB_IMAGE_COMPRESSION}"
-  eib_compress_image "${out_img}" "${out_zimg}"
-  sign_file "${out_zimg}"
+  eib_compress_image "${out_img}" "${out_zimg}" &
+  wait
+
+  sign_file "${out_zimg}" &
+  checksum_file "${out_zimg}" &
   local out_zimg_size=$(stat -c "%s" "${out_zimg}")
   local out_zimg_signature=$(basename "${out_zimg}.asc")
+  local out_zimg_checksum=$(basename "${out_zimg}.sha256")
+  wait
 
   # Remove uncompressed image.
   rm -f "${out_img}"
@@ -114,7 +126,8 @@ create_usb_image() {
       "extracted_size": ${out_img_size},
       "compressed_size": ${out_zimg_size},
       "compression_type": "${EIB_IMAGE_COMPRESSION}",
-      "signature": "${out_zimg_signature}"
+      "signature": "${out_zimg_signature}",
+      "checksum": "${out_zimg_checksum}"
     }
   }
 }

--- a/helpers/create-vm-image
+++ b/helpers/create-vm-image
@@ -14,13 +14,16 @@ create_ovf_zip() {
 
   # Generate .zip and .zip.size containing the total uncompressed size
   "${EIB_HELPERSDIR}"/generate-ovf-files --cpus 1 --memory 2048 --extra-storage 10 ${img} ${ovfzip}
-  sign_file ${ovfzip}
+  sign_file ${ovfzip} &
+  checksum_file ${ovfzip} &
+  wait
 
   # Generate OVF manifest information
   local ovf_name=$(basename "${ovfzip}")
   local ovf_uncompressed_size=$(cat "${ovfzip}.size")
   local ovf_compressed_size=$(stat -c "%s" "${ovfzip}")
   local ovf_signature=$(basename "${ovfzip}.asc")
+  local ovf_checksum=$(basename "${ovfzip}.sha256")
 
   cat > "${EIB_MANIFESTDIR}"/ovf.json <<EOF
 {
@@ -30,7 +33,8 @@ create_ovf_zip() {
       "extracted_size": ${ovf_uncompressed_size},
       "compressed_size": ${ovf_compressed_size},
       "compression_type": "zip",
-      "signature": "${ovf_signature}"
+      "signature": "${ovf_signature}",
+      "checksum": "${ovf_checksum}"
     }
   }
 }

--- a/helpers/split-image
+++ b/helpers/split-image
@@ -181,6 +181,10 @@ split_image() {
   disk1_img_asc=$(eib_outfile disk1.img.asc)
   disk2_img_asc=$(eib_outfile disk2.img.asc)
 
+  local disk1_img_csum disk2_img_csum
+  disk1_img_asc=$(eib_outfile disk1.img.sha256)
+  disk2_img_asc=$(eib_outfile disk2.img.sha256)
+
   # Mount root filesystem from the last partition of the image file.
   DISK1_LOOP=$(losetup --show -f "${disk1_img}")
   eib_partx_scan "${DISK1_LOOP}"
@@ -331,17 +335,21 @@ split_image() {
   echo "${disk1_extracted_size}" > "${disk1_zimg}.size"
   echo "${disk2_extracted_size}" > "${disk2_zimg}.size"
 
-  # Create signatures for uncompressed images.
+  # Create signatures and checksums for uncompressed images.
   sign_file "${disk1_img}" "${disk1_img_asc}" &
   sign_file "${disk2_img}" "${disk2_img_asc}" &
+  checksum_file "${disk1_img}" "${disk1_img_csum}" &
+  checksum_file "${disk2_img}" "${disk2_img_csum}" &
 
   # Compress image files.
   eib_compress_image "${disk1_img}" "${disk1_zimg}"
   eib_compress_image "${disk2_img}" "${disk2_zimg}"
 
-  # Create signatures for compressed images.
+  # Create signatures and checksums for compressed images.
   sign_file "${disk1_zimg}" &
   sign_file "${disk2_zimg}" &
+  checksum_file "${disk1_zimg}" &
+  checksum_file "${disk2_zimg}" &
 
   # Remove uncompressed images once signatures have been created.
   wait
@@ -349,15 +357,17 @@ split_image() {
   rm -f "${disk2_img}"
 
   # Generate split disk manifest information
-  local disk1_name disk1_compressed_size disk1_signature
+  local disk1_name disk1_compressed_size disk1_signature disk1_checksum
   disk1_name=$(basename "${disk1_zimg}")
   disk1_compressed_size=$(stat -c "%s" "${disk1_zimg}")
   disk1_signature="${disk1_name}.asc"
+  disk1_checksum="${disk1_name}.sha256"
 
-  local disk2_name disk2_compressed_size disk2_signature
+  local disk2_name disk2_compressed_size disk2_signature disk2_checksum
   disk2_name=$(basename "${disk2_zimg}")
   disk2_compressed_size=$(stat -c "%s" "${disk2_zimg}")
   disk2_signature="${disk2_name}.asc"
+  disk2_checksum="${disk2_name}.sha256"
   cat > "${EIB_MANIFESTDIR}"/split-images.json <<EOF
 {
   "images": {
@@ -366,14 +376,16 @@ split_image() {
       "extracted_size": ${disk1_extracted_size},
       "compressed_size": ${disk1_compressed_size},
       "compression_type": "${EIB_IMAGE_COMPRESSION}",
-      "signature": "${disk1_signature}"
+      "signature": "${disk1_signature}",
+      "checksum": "${disk1_checksum}"
     },
     "disk2": {
       "file": "${disk2_name}",
       "extracted_size": ${disk2_extracted_size},
       "compressed_size": ${disk2_compressed_size},
       "compression_type": "${EIB_IMAGE_COMPRESSION}",
-      "signature": "${disk2_signature}"
+      "signature": "${disk2_signature}",
+      "checksum": "${disk2_checksum}"
     }
   }
 }

--- a/hooks/publish/42-sha256sums
+++ b/hooks/publish/42-sha256sums
@@ -1,7 +1,13 @@
-# Create a SHA256SUMS{,.gpg} file of the entire directory, useful for
-# verifying downloads when using machinectl. sha256sum needs to be run in the
-# right directory so that it outputs appropriate relative paths.
+# Create a SHA256SUMS{,.gpg} file consisting of all the individual
+# checksum files. This is useful for verifying downloads when using
+# machinectl. Some of the checksums are created for files that are
+# embedded in other images, so make sure the original file exists.
 pushd "${EIB_OUTDIR}"
-sha256sum * > SHA256SUMS
+for checksum in *.sha256; do
+    asset=${checksum%.sha256}
+    if [ -f "${asset}" ]; then
+        awk "{print \$1 \"  ${asset}\"}" "${checksum}"
+    fi
+done > SHA256SUMS
 popd
 sign_file "${EIB_OUTDIR}/SHA256SUMS" "${EIB_OUTDIR}/SHA256SUMS.gpg"

--- a/lib/eib.sh
+++ b/lib/eib.sh
@@ -271,6 +271,14 @@ sign_file() {
   fi
 }
 
+# Create a detached checksum with sha256sum.
+checksum_file() {
+  local file=${1:?No file supplied to ${FUNCNAME}}
+  local outfile=${2:-${file}.sha256}
+
+  sha256sum "${file}" | cut -d' ' -f1 > "${outfile}"
+}
+
 # Emulate the old ostree write-refs builtin where a local ref is forced
 # to the commit of another ref.
 ostree_write_refs() {

--- a/stages/eib_image
+++ b/stages/eib_image
@@ -402,17 +402,20 @@ EOF
             local uboot_spi_zip="$(eib_outfile uboot-spi.zip)"
             zip "${uboot_spi_zip}" "${DEPLOY}"/usr/lib/u-boot/chromebook_jerry/u-boot.SPI
             sign_file "${uboot_spi_zip}" &
+            checksum_file "${uboot_spi_zip}" &
 
             # Generate manifest information
             local uboot_spi_zip_name=$(basename "${uboot_spi_zip}")
             local uboot_spi_zip_size=$(stat -c "%s" "${uboot_spi_zip}")
             local uboot_spi_zip_signature="${uboot_spi_zip_name}.asc"
+            local uboot_spi_zip_checksum="${uboot_spi_zip_name}.sha256"
             cat >> "${img_manifest}" <<EOF
     "uboot-spi": {
       "file": "${uboot_spi_zip_name}",
       "compressed_size": ${uboot_spi_zip_size},
       "compression_type": "zip",
-      "signature": "${uboot_spi_zip_signature}"
+      "signature": "${uboot_spi_zip_signature}",
+      "checksum": "${uboot_spi_zip_checksum}"
     },
 EOF
           fi
@@ -584,17 +587,20 @@ EOF
         (cd "${boot_zip_dir}" && zip "${boot_zip}" -r *)
         rm -r "${boot_zip_dir}"
         sign_file "${boot_zip}" &
+        checksum_file "${boot_zip}" &
 
         # Generate manifest information
         local boot_zip_name=$(basename "${boot_zip}")
         local boot_zip_size=$(stat -c "%s" "${boot_zip}")
         local boot_zip_signature="${boot_zip_name}.asc"
+        local boot_zip_checksum="${boot_zip_name}.sha256"
         cat >> "${img_manifest}" <<EOF
     "boot": {
       "file": "${boot_zip_name}",
       "compressed_size": ${boot_zip_size},
       "compression_type": "zip",
-      "signature": "${boot_zip_signature}"
+      "signature": "${boot_zip_signature}",
+      "checksum": "${boot_zip_checksum}"
     },
 EOF
       elif [[ "${EIB_IMAGE_SDBOOT}" == "true" ]]; then
@@ -639,9 +645,12 @@ EOF
   # Cleanup devices
   cleanup_devices
 
-  # Sign uncompressed image (used when installing from a live image)
+  # Sign and checksum uncompressed image (used when installing from a
+  # live image)
   local img_asc="$(eib_outfile img.asc)"
+  local img_csum="$(eib_outfile img.sha256)"
   sign_file "${img}" "${img_asc}" &
+  checksum_file "${img}" "${img_csum}" &
 
   # Publish uncompressed file size.
   local img_extracted_size=$(stat -c "%s" "${img}")
@@ -650,21 +659,24 @@ EOF
   # Compress image file.
   eib_compress_image "${img}" "${outfile}"
 
-  # Sign compressed image (used to verify download)
+  # Sign and checksum compressed image (used to verify download)
   sign_file ${outfile} &
+  checksum_file ${outfile} &
 
   # Copy ostree, package and config info to the output directory.
   cp "${EIB_TMPDIR}"/ostree.txt "$(eib_outfile ostree.txt)"
   cp "${EIB_TMPDIR}"/packages.txt "$(eib_outfile packages.txt)"
   cp "${EIB_TMPDIR}"/config.ini "$(eib_outfile config.ini)"
 
-  # Create ISO if required. This requires the uncompressed image, its
-  # signature, and the signature for boot.zip. In theory we could `wait` only
-  # for those two signatures and allow compressing the image and signing it to
-  # happen in parallel with creating the ISO.
+  # Create ISO if required. This requires the uncompressed image,
+  # boot.zip and eheir associated checksums and signatures. In theory we
+  # could `wait` only for the checksums and signatures and allow
+  # compressing the image and signing it to happen in parallel with
+  # creating the ISO.
   if [[ "${EIB_IMAGE_ISO}" = "true" && "$EIB_IMAGE_BOOT_ZIP" = "true" ]]; then
     "${EIB_HELPERSDIR}"/create-iso "${version}" "$(eib_outfile iso)" \
-      "${img}" "${boot_zip}" "${img_asc}" "${boot_zip}.asc"
+      "${img}" "${boot_zip}" "${img_csum}" "${boot_zip}.sha256" "${img_asc}" \
+      "${boot_zip}.asc"
   fi
 
   # Create VM image if required
@@ -683,10 +695,11 @@ EOF
   # This expects to have an ISO image for eos-write-live-image.
   if [[ "${EIB_IMAGE_USB}" = "true" && "${EIB_IMAGE_ISO}" = "true" && "${EIB_IMAGE_BOOT_ZIP}" = "true" ]]; then
     "${EIB_HELPERSDIR}"/create-usb-image "${version}" "$(eib_outfile usb.img)" \
-      "$(eib_outfile iso)" "${boot_zip}" "${img_asc}" "${boot_zip}.asc"
+      "$(eib_outfile iso)" "${boot_zip}" "${img_csum}" "${boot_zip}.sha256" \
+      "${img_asc}" "${boot_zip}.asc"
   fi
 
-  # Await sign_file subprocesses
+  # Await signing and checksumming subprocesses
   wait
 
   # Remove uncompressed image
@@ -696,13 +709,15 @@ EOF
   local img_name=$(basename "${outfile}")
   local img_compressed_size=$(stat -c "%s" "${outfile}")
   local img_signature="${img_name}.asc"
+  local img_checksum="${img_name}.sha256"
   cat >> "${img_manifest}" <<EOF
     "full": {
       "file": "${img_name}",
       "extracted_size": ${img_extracted_size},
       "compressed_size": ${img_compressed_size},
       "compression_type": "${EIB_IMAGE_COMPRESSION}",
-      "signature": "${img_signature}"
+      "signature": "${img_signature}",
+      "checksum": "${img_checksum}"
     }
   }
 }


### PR DESCRIPTION
In addition to the combined `SHA256SUMS` file, generate per-asset checksum files in the output directory. This can provide asset verification when GPG signing isn't enabled or when GPG verification is too complex for the consumer.

https://phabricator.endlessm.com/T31076