### PR TITLE
Full sha256sum files

### DIFF
--- a/helpers/split-image
+++ b/helpers/split-image
@@ -182,8 +182,8 @@ split_image() {
   disk2_img_asc=$(eib_outfile disk2.img.asc)
 
   local disk1_img_csum disk2_img_csum
-  disk1_img_asc=$(eib_outfile disk1.img.sha256)
-  disk2_img_asc=$(eib_outfile disk2.img.sha256)
+  disk1_img_csum=$(eib_outfile disk1.img.sha256)
+  disk2_img_csum=$(eib_outfile disk2.img.sha256)
 
   # Mount root filesystem from the last partition of the image file.
   DISK1_LOOP=$(losetup --show -f "${disk1_img}")

--- a/helpers/split-image
+++ b/helpers/split-image
@@ -181,9 +181,11 @@ split_image() {
   disk1_img_asc=$(eib_outfile disk1.img.asc)
   disk2_img_asc=$(eib_outfile disk2.img.asc)
 
-  local disk1_img_csum disk2_img_csum
+  local disk1_img_csum disk1_img_csum_tgt disk2_img_csum disk2_img_csum_tgt
   disk1_img_csum=$(eib_outfile disk1.img.sha256)
+  disk1_img_csum_tgt="${EIB_OUTVERSION}.disk1.img"
   disk2_img_csum=$(eib_outfile disk2.img.sha256)
+  disk2_img_csum_tgt="${EIB_OUTVERSION}.disk2.img"
 
   # Mount root filesystem from the last partition of the image file.
   DISK1_LOOP=$(losetup --show -f "${disk1_img}")
@@ -338,8 +340,8 @@ split_image() {
   # Create signatures and checksums for uncompressed images.
   sign_file "${disk1_img}" "${disk1_img_asc}" &
   sign_file "${disk2_img}" "${disk2_img_asc}" &
-  checksum_file "${disk1_img}" "${disk1_img_csum}" &
-  checksum_file "${disk2_img}" "${disk2_img_csum}" &
+  checksum_file "${disk1_img}" "${disk1_img_csum}" "${disk1_img_csum_tgt}" &
+  checksum_file "${disk2_img}" "${disk2_img_csum}" "${disk2_img_csum_tgt}" &
 
   # Compress image files.
   eib_compress_image "${disk1_img}" "${disk1_zimg}"

--- a/hooks/publish/42-sha256sums
+++ b/hooks/publish/42-sha256sums
@@ -4,9 +4,9 @@
 # embedded in other images, so make sure the original file exists.
 pushd "${EIB_OUTDIR}"
 for checksum in *.sha256; do
-    asset=${checksum%.sha256}
+    read -r _ asset < "${checksum}"
     if [ -f "${asset}" ]; then
-        awk "{print \$1 \"  ${asset}\"}" "${checksum}"
+        cat "${checksum}"
     fi
 done > SHA256SUMS
 popd

--- a/lib/eib.sh
+++ b/lib/eib.sh
@@ -271,12 +271,16 @@ sign_file() {
   fi
 }
 
-# Create a detached checksum with sha256sum.
+# Create a detached checksum with sha256sum. By default the target in
+# the checksum file is the basename of the file being checksummed.
 checksum_file() {
   local file=${1:?No file supplied to ${FUNCNAME}}
   local outfile=${2:-${file}.sha256}
+  local target=${3:-${file##*/}}
+  local checksum
 
-  sha256sum "${file}" | cut -d' ' -f1 > "${outfile}"
+  checksum=$(sha256sum "${file}" | cut -d' ' -f1)
+  echo "${checksum}  ${target}" > "${outfile}"
 }
 
 # Emulate the old ostree write-refs builtin where a local ref is forced

--- a/stages/eib_image
+++ b/stages/eib_image
@@ -649,8 +649,9 @@ EOF
   # live image)
   local img_asc="$(eib_outfile img.asc)"
   local img_csum="$(eib_outfile img.sha256)"
+  local img_csum_tgt="${EIB_OUTVERSION}.img"
   sign_file "${img}" "${img_asc}" &
-  checksum_file "${img}" "${img_csum}" &
+  checksum_file "${img}" "${img_csum}" "${img_csum_tgt}" &
 
   # Publish uncompressed file size.
   local img_extracted_size=$(stat -c "%s" "${img}")

--- a/tests/test_eib_sh.py
+++ b/tests/test_eib_sh.py
@@ -180,18 +180,25 @@ def test_checksum_file(make_builder, tmp_path):
     assert proc.returncode != 0
     assert 'No file supplied' in proc.stderr.decode('utf-8')
 
-    # Sign a file with the default output and verify it
+    # Checksum a file with the default output and verify it
     script = 'checksum_file {}'.format(test_file)
     run_lib(builder, script)
     assert test_csum.exists()
-    assert test_csum.read_text() == expected_checksum + '\n'
+    assert test_csum.read_text() == '{}  test\n'.format(expected_checksum)
 
-    # Sign a file with a specified output and verify it
+    # Checksum a file with a specified output and verify it
     csum_file = tmp_path / 'checksum'
     script = 'checksum_file {} {}'.format(test_file, csum_file)
     run_lib(builder, script)
     assert csum_file.exists()
-    assert csum_file.read_text() == expected_checksum + '\n'
+    assert csum_file.read_text() == '{}  test\n'.format(expected_checksum)
+
+    # Checksum a file with a specified output and target and verify it
+    csum_file = tmp_path / 'checksum'
+    script = 'checksum_file {} {} {}'.format(test_file, csum_file, 'target')
+    run_lib(builder, script)
+    assert csum_file.exists()
+    assert csum_file.read_text() == '{}  target\n'.format(expected_checksum)
 
 
 def test_run_hooks(make_builder, tmp_bindir, tmp_path):


### PR DESCRIPTION
Include the target in the individual checksum files so that they can be passed to `sha256sum --check` like the combined checksum file.

https://phabricator.endlessm.com/T31076