### PR TITLE
eib_image: Make U-Boot load corresponding DTB directly

### DIFF
--- a/data/arm64/boot.src
+++ b/data/arm64/boot.src
@@ -3,19 +3,7 @@ ext4load ${devtype} ${devnum}:${distro_bootpart} ${scriptaddr} /boot/uEnv.txt
 env import -t ${scriptaddr} ${filesize}
 
 echo "Load device tree ..."
-# Documented approach of passing ${addr}:${fdt_notation} doesn't work and we
-# don't know why.  However, we can find the start address of the specific device
-# tree corresponding to ${fdt_notation} in /boot/${fdt_file} and relocate it to
-# the designed ${fdt_addr_r}.  We do not know why relocation is necessary, but
-# suspect it is because the FDT start address should be aligned.
-fdt_load_addr_r=${ramdisk_addr_r}
-ext4load ${devtype} ${devnum}:${distro_bootpart} ${fdt_load_addr_r} /boot/${fdt_file}
-fdt addr ${fdt_load_addr_r}
-setexpr fdt_notation gsub / _ ${fdtfile}
-fdt get addr fdt_start_addr_r /images/${fdt_notation} data
-fdt get size fdt_size /images/${fdt_notation} data
-fdt move ${fdt_start_addr_r} ${fdt_addr_r} ${fdt_size}
-fdt addr ${fdt_addr_r}
+ext4load ${devtype} ${devnum}:${distro_bootpart} ${fdt_addr_r} /boot/${fdtdir}/${fdtfile}
 
 echo "Load kernel and unzip it ..."
 kernel_load_addr_r=${ramdisk_addr_r}

--- a/stages/eib_image
+++ b/stages/eib_image
@@ -427,12 +427,12 @@ EOF
       esac
       ;;
     arm64)
-      cp "${EIB_DATADIR}"/arm64/boot.src "${EIB_TMPDIR}"/boot.scr
-      sed -i "1s/^/"$platform_bootargs"\n/" "${EIB_TMPDIR}"/boot.scr
+      cp "${EIB_DATADIR}"/arm64/boot.src "${EIB_TMPDIR}"/boot.src
+      sed -i "1s/^/"$platform_bootargs"\n/" "${EIB_TMPDIR}"/boot.src
 
       # Make a boot script for u-boot
       mkimage -T script -C none -n "Endless OS arm64 boot script" -d \
-        "${EIB_TMPDIR}"/boot.scr \
+        "${EIB_TMPDIR}"/boot.src \
         "${ROOT}"/boot/boot.scr
 
       case "${EIB_PLATFORM}" in


### PR DESCRIPTION
EOS makes OSTree deploy device tree folder for arm64 platforms, instead
of a single FIT-uImage including multiple DTBs. So, U-Boot's boot script
should load the DTB in the corresponding path simply and directly.

https://phabricator.endlessm.com/T31726