### PR TITLE
image: Fix race between ISO and checksum creation

### DIFF
--- a/stages/eib_image
+++ b/stages/eib_image
@@ -670,11 +670,14 @@ EOF
   cp "${EIB_TMPDIR}"/config.ini "$(eib_outfile config.ini)"
 
   # Create ISO if required. This requires the uncompressed image,
-  # boot.zip and eheir associated checksums and signatures. In theory we
-  # could `wait` only for the checksums and signatures and allow
-  # compressing the image and signing it to happen in parallel with
-  # creating the ISO.
+  # boot.zip and their associated checksums and signatures.
   if [[ "${EIB_IMAGE_ISO}" = "true" && "$EIB_IMAGE_BOOT_ZIP" = "true" ]]; then
+    # Make sure the uncompressed checksums and signatures have
+    # completed. In theory we could `wait` only for the checksums and
+    # signatures and allow compressing the image and signing it to
+    # happen in parallel with creating the ISO.
+    wait
+
     "${EIB_HELPERSDIR}"/create-iso "${version}" "$(eib_outfile iso)" \
       "${img}" "${boot_zip}" "${img_csum}" "${boot_zip}.sha256" "${img_asc}" \
       "${boot_zip}.asc"


### PR DESCRIPTION
In d8e43c39272d39131a560ff2f2be61ca556d77e3 the split image process was
moved after the ISO creation since it destructively edits the raw image.
However, this also moved the `wait` that was blocking on the
uncompressed signature file which the ISO creation needed. This
sometimes causes a race if the signature isn't completed before
`create-iso` is called.

Unfortunately, previously the race would be silently ignored because
`create-iso` assumes that if the signature file didn't exist it was
intentional. However, now it has a hard requirement on the uncompressed
image checksum file, which is also created in the background at the same
time.

This adds back the wait with a slight optimization that it only happens
when creating an ISO.

https://phabricator.endlessm.com/T31304