### PR TITLE
config: Add Kolibri content to the base personality

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -281,11 +281,16 @@ automatic_provision_landing_page = learn
 #
 # [kolibri-e8a879742b2249a0a4b890f9903916f7]
 # include_node_ids =
-#   # English [topic - 23]
+#   # English [topic]
 #   3b909a18242c48208dbc49d06bc48162
 # exclude_node_ids =
 #   # Kolibri 0.12.2 User Guide for Admins [document]
 #   5bb37c1832c8489ab2940f31588305f6
+
+[kolibri-e8a879742b2249a0a4b890f9903916f7]
+include_node_ids =
+  # English [topic]
+  3b909a18242c48208dbc49d06bc48162
 
 [usb]
 size = 16000000000

--- a/config/personality/base.ini
+++ b/config/personality/base.ini
@@ -12,3 +12,9 @@ apps_del = ${apps_add_defaults}
 [flatpak-remote-flathub]
 # Delete all default additions and explicitly build the list from scratch.
 apps_del = ${apps_add_defaults}
+apps_add =
+  org.learningequality.Kolibri
+
+[kolibri]
+install_channels =
+  e8a879742b2249a0a4b890f9903916f7

--- a/config/personality/es.ini
+++ b/config/personality/es.ini
@@ -39,3 +39,8 @@ apps_add =
   com.endlessm.travel.es
   com.endlessm.water_and_sanitation.es
   com.endlessm.world_literature.es
+
+[kolibri-e8a879742b2249a0a4b890f9903916f7]
+include_node_ids =
+  # Español [topic]
+  6e8f60c6b9c841969853d48f4eff22cf

--- a/config/personality/fr.ini
+++ b/config/personality/fr.ini
@@ -13,3 +13,8 @@ locales = fr
 [flatpak-remote-eos-apps]
 apps_add =
   com.endlessm.encyclopedia.fr
+
+[kolibri-e8a879742b2249a0a4b890f9903916f7]
+include_node_ids =
+  # Français [topic]
+  0b70a374af244baaa2b795530c2c0b55


### PR DESCRIPTION
This adds some simple Kolibri content (and automatic provisioning) to the `base` personality.

https://phabricator.endlessm.com/T31866