### PR TITLE
Remove python2 from buildroot

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -94,7 +94,6 @@ packages_add =
   p7zip-full
   parted
   pigz
-  python
   python3
   python3-apt
   python3-gi


### PR DESCRIPTION
I was able to build images fine without it and don't see any scripts that need it.