### PR TITLE
config: Do not include org.freedesktop.Platform.openh264 for arm64

### DIFF
--- a/config/arch/arm64.ini
+++ b/config/arch/arm64.ini
@@ -11,6 +11,11 @@ iso = false
 hooks_del = 50-google-chrome
 
 [flatpak-remote-flathub]
+# These extensions are not available for arm64
+# https://gitlab.com/freedesktop-sdk/openh264-extension/-/issues/2
+runtimes_del =
+  org.freedesktop.Platform.openh264
+
 apps_del =
   edu.mit.Scratch
   cc.arduino.arduinoide


### PR DESCRIPTION
This runtime extension is not available for arm64.

https://phabricator.endlessm.com/T30865