### PR TITLE
config: Set eos-apps repo to use eos3 branch by default

### DIFF
--- a/config/branch/master.ini
+++ b/config/branch/master.ini
@@ -3,8 +3,3 @@
 [ostree]
 # Use the dev repo for deployment since master is never released
 deploy_url = ${dev_deploy_repo_url}/${repo}
-
-[flatpak-remote-eos-apps]
-# Endless apps are now published to the eos3 branch rather than master.
-# This default to the series, which would be master here.
-default_branch = eos3

--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -425,7 +425,8 @@ enable_p2p_updates = true
 [flatpak-remote-eos-apps]
 url = ${ostree:prod_pull_repo_url}/eos-apps
 deploy_url = ${ostree:prod_deploy_repo_url}/eos-apps
-default_branch = ${build:series}
+# The latest Endless apps are currently published to the eos3 branch.
+default_branch = eos3
 apps_add =
   com.endlessm.finance
   com.endlessm.resume


### PR DESCRIPTION
The latest eos-apps are available on the eos3 branch of the eos-apps
flatpak repo. We are not develpoing these apps anymore, so it probably
does not make sense to push a eos4 ref to this repo.

https://phabricator.endlessm.com/T32376