### PR TITLE
Revert "Skip flatpak parental controls checks when running from the b…

### DIFF
--- a/hooks/content/50-flatpak
+++ b/hooks/content/50-flatpak
@@ -24,10 +24,6 @@ if not config.getboolean('flatpak', 'enable', fallback=True):
 # Enable debug logging for all flatpak operations
 os.environ['G_MESSAGES_DEBUG'] = 'flatpak'
 
-# Skip flatpak parental controls checks when running from
-# the builder - see https://phabricator.endlessm.com/T27896.
-os.environ['FLATPAK_SKIP_PARENTAL_CONTROLS_NO_SYSTEM_BUS'] = '1'
-
 # Create the ostree repository before opening the installation so an
 # archive-z2 repo can be used. That saves disk space on the builder
 # since the objects won't be able to be checked out anywhere.

--- a/hooks/image/50-flatpak.chroot
+++ b/hooks/image/50-flatpak.chroot
@@ -23,10 +23,6 @@ if not config.getboolean('flatpak', 'enable', fallback=True):
 # Enable debug logging for all flatpak operations
 os.environ['G_MESSAGES_DEBUG'] = 'flatpak'
 
-# Skip flatpak parental controls checks when running from
-# the builder - see https://phabricator.endlessm.com/T27896.
-os.environ['FLATPAK_SKIP_PARENTAL_CONTROLS_NO_SYSTEM_BUS'] = '1'
-
 # Make sure we set the correct XDG_DATA_DIRS when installing, or the
 # triggers won't work properly. Normally these are always set when
 # running in a session, but may not on Jenkins. See also


### PR DESCRIPTION
…uilder"

This reverts commit 2c1c0919dad298c538dcafae4b60720022177e68.

Due to T32545, which has landed on `master` and `eos4.0`, flatpak now
always ignores parental controls when run as the `root` user. This means
that we should no longer need this workaround for ignoring parental
controls in the image builder (which runs as `root`).

This commit can be backported to `eos4.0`, but no earlier. The version
of flatpak in earlier EOS branches does not have the fix for `root`.

https://phabricator.endlessm.com/T27896