### PR TITLE
config: Follow latest1 ostree branch by default

### DIFF
--- a/config/branch/master.ini
+++ b/config/branch/master.ini
@@ -3,3 +3,6 @@
 [ostree]
 # Use the dev repo for deployment since master is never released
 deploy_url = ${dev_deploy_repo_url}/${repo}
+
+# Master images should always follow the master ostree.
+stable_branch = ${build:branch}

--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -291,10 +291,14 @@ repo = eos
 os = eos
 remote = eos
 
-# Multiple stable minor version branches may be in use, but the deployed
-# ostree configuration should use only the major version. E.g., the real
-# branch may be eos2.2, but the deployed configuration should use eos2.
-stable_branch = ${build:series}
+# By default the deployed ostree configuration should follow the latestX
+# branch rather than the branch used for the build. This way they'll
+# always follow our latest release.
+#
+# For LTS builds this may be the built branch (e.g., eos4.0) or the
+# major series branch (e.g., eos4) to keep the system on a specific EOS
+# version.
+stable_branch = latest1
 ref_deploy = os/${product}/${platform}/${stable_branch}
 
 # Builder directories


### PR DESCRIPTION
We'd like new images to track the `latestX` ostree branch across major
versions rather than following the major series `eosN` branch. The major
series branches still exist and may be used by LTS products that are
designed to stay on a specific version of EOS.

https://phabricator.endlessm.com/T32596