### PR TITLE
config: Adjust pre-loaded Kolibri content on base, en, es, fr and pt_BR images

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -246,6 +246,11 @@ automatic_provision_preset = nonformal
 automatic_provision_landing_page = learn
 
 # Preloaded Kolibri channels
+#
+# Note: this content on this channel is outdated, so we are leaving
+# it out of the images until it gets updated to match the new Kolibri
+# experience on Endless OS.
+#
 # install_channels =
 #   # How to get started with Kolibri on Endless OS
 #   e8a879742b2249a0a4b890f9903916f7

--- a/config/personality/base.ini
+++ b/config/personality/base.ini
@@ -14,7 +14,3 @@ apps_del = ${apps_add_defaults}
 apps_del = ${apps_add_defaults}
 apps_add =
   org.learningequality.Kolibri
-
-[kolibri]
-install_channels =
-  e8a879742b2249a0a4b890f9903916f7

--- a/config/personality/en.ini
+++ b/config/personality/en.ini
@@ -30,3 +30,5 @@ apps_add =
 install_channels =
   # Khan Academy (English - US curriculum) [2348]
   c9d7f950ab6b5a1199e3d6c10d7f0103
+  # TED-Ed Endless Key [complete]
+  2091ca47ff544c96b4ae02b3a92346e1

--- a/config/personality/en.ini
+++ b/config/personality/en.ini
@@ -25,8 +25,3 @@ apps_add =
   com.endlessnetwork.drawingtutorials
   com.endlessnetwork.htmltutorials
   com.endlessnetwork.sciencesnacks
-
-[kolibri]
-install_channels =
-  # How to get started with Kolibri on Endless OS
-  e8a879742b2249a0a4b890f9903916f7

--- a/config/personality/en.ini
+++ b/config/personality/en.ini
@@ -25,3 +25,8 @@ apps_add =
   com.endlessnetwork.drawingtutorials
   com.endlessnetwork.htmltutorials
   com.endlessnetwork.sciencesnacks
+
+[kolibri]
+install_channels =
+  # Khan Academy (English - US curriculum) [2348]
+  c9d7f950ab6b5a1199e3d6c10d7f0103

--- a/config/personality/es.ini
+++ b/config/personality/es.ini
@@ -40,6 +40,11 @@ apps_add =
   com.endlessm.water_and_sanitation.es
   com.endlessm.world_literature.es
 
+[kolibri]
+install_channels =
+  # Khan Academy (Español)
+  c1f2b7e6ac9f56a2bb44fa7a48b66dce
+
 [kolibri-e8a879742b2249a0a4b890f9903916f7]
 include_node_ids =
   # Español [topic]

--- a/config/personality/fr.ini
+++ b/config/personality/fr.ini
@@ -14,6 +14,11 @@ locales = fr
 apps_add =
   com.endlessm.encyclopedia.fr
 
+[kolibri]
+install_channels =
+  # Khan Academy (Français)
+  878ec2e6f88c5c268b1be6f202833cd4
+
 [kolibri-e8a879742b2249a0a4b890f9903916f7]
 include_node_ids =
   # Français [topic]

--- a/config/personality/pt_BR.ini
+++ b/config/personality/pt_BR.ini
@@ -33,3 +33,8 @@ apps_add =
   com.endlessm.socialsciences.pt
   com.endlessm.travel.pt
   com.endlessm.your_health.pt_BR
+
+[kolibri]
+install_channels =
+  # Khan Academy (Português (Brasil))
+  2ac071c4672354f2aa78953448f81e50


### PR DESCRIPTION
Drops outdated "Kolibri on Endless OS" documentation channel and includes localized Khan Academy content and the TED-Ed Kolibri channel.

https://phabricator.endlessm.com/T32693