### PR TITLE
config: Drop the section for the "Kolibri on EOS" channel from default, es, fr, pt_BR

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -276,11 +276,6 @@ automatic_provision_landing_page = learn
 #   # Kolibri 0.12.2 User Guide for Admins [document]
 #   5bb37c1832c8489ab2940f31588305f6
 
-[kolibri-e8a879742b2249a0a4b890f9903916f7]
-include_node_ids =
-  # English [topic]
-  3b909a18242c48208dbc49d06bc48162
-
 [usb]
 size = 16000000000
 free_space = 1000

--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -272,6 +272,8 @@ automatic_provision_landing_page = learn
 # include_node_ids =
 #   # English [topic]
 #   3b909a18242c48208dbc49d06bc48162
+#   # Español [topic]
+#   6e8f60c6b9c841969853d48f4eff22cf
 # exclude_node_ids =
 #   # Kolibri 0.12.2 User Guide for Admins [document]
 #   5bb37c1832c8489ab2940f31588305f6

--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -274,6 +274,8 @@ automatic_provision_landing_page = learn
 #   3b909a18242c48208dbc49d06bc48162
 #   # Español [topic]
 #   6e8f60c6b9c841969853d48f4eff22cf
+#   # Français [topic]
+#   0b70a374af244baaa2b795530c2c0b55
 # exclude_node_ids =
 #   # Kolibri 0.12.2 User Guide for Admins [document]
 #   5bb37c1832c8489ab2940f31588305f6

--- a/config/personality/es.ini
+++ b/config/personality/es.ini
@@ -44,8 +44,3 @@ apps_add =
 install_channels =
   # Khan Academy (Español)
   c1f2b7e6ac9f56a2bb44fa7a48b66dce
-
-[kolibri-e8a879742b2249a0a4b890f9903916f7]
-include_node_ids =
-  # Español [topic]
-  6e8f60c6b9c841969853d48f4eff22cf

--- a/config/personality/fr.ini
+++ b/config/personality/fr.ini
@@ -18,8 +18,3 @@ apps_add =
 install_channels =
   # Khan Academy (Français)
   878ec2e6f88c5c268b1be6f202833cd4
-
-[kolibri-e8a879742b2249a0a4b890f9903916f7]
-include_node_ids =
-  # Français [topic]
-  0b70a374af244baaa2b795530c2c0b55


### PR DESCRIPTION
We are not installing this channel by default anymore, but having the
section specifying its node ids ends up pulling the channel in anyway.

https://phabricator.endlessm.com/T32693