### PR TITLE
kolibri: Clear local dir before downloading content

### DIFF
--- a/hooks/image/60-kolibri-content
+++ b/hooks/image/60-kolibri-content
@@ -27,6 +27,12 @@ import_kolibri_channel()
 
 # Needs to be kept in sync with hooks/image/61-kolibri-content-install
 KOLIBRI_CONTENT_DIR="${EIB_CONTENTDIR}/kolibri-content"
+# FIXME: For now, we need to remove old content that may exist from previous
+# runs to prevent images accidentally getting extra channels that are not in
+# their configuration. However, this defeats the purpose of the image builder
+# saving the contents of EIB_CONTENTDIR between runs to improve its performance.
+# At some point we should revisit this to try to make the caching work properly.
+rm -rf "${KOLIBRI_CONTENT_DIR}"
 mkdir -p "${KOLIBRI_CONTENT_DIR}"
 
 venv_dir="${EIB_TMPDIR}/kolibri-content-venv"


### PR DESCRIPTION
When the hook that downloads Kolibri content runs, its target directory
may already exist and have content from the previous run, which may be
from a different image configuration.

This commit removes any previously exiting content to prevent that
content from being included in the image being built.

https://phabricator.endlessm.com/T32712