### PR TITLE
kolibri: Add options for desktop auth plugin

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -237,6 +237,8 @@ branding_subst_vars_add =
 [kolibri]
 app_version = 0.14.7
 app_desktop_xdg_plugin_version = 1.0.9
+desktop_auth_plugin_version = 0.0.6
+desktop_auth_plugin_regular_users_can_manage_content = false
 
 automatic_provision = true
 automatic_provision_facility_name = Endless

--- a/hooks/image/60-kolibri-content
+++ b/hooks/image/60-kolibri-content
@@ -41,6 +41,7 @@ source ${venv_dir}/bin/activate
 
 pip install kolibri==${EIB_KOLIBRI_APP_VERSION}
 pip install kolibri-app-desktop-xdg-plugin==${EIB_KOLIBRI_APP_DESKTOP_XDG_PLUGIN_VERSION}
+pip install kolibri-desktop-auth-plugin==${EIB_KOLIBRI_DESKTOP_AUTH_PLUGIN_VERSION}
 
 export KOLIBRI_HOME="${KOLIBRI_CONTENT_DIR}"
 
@@ -50,9 +51,16 @@ cat << EOF > "${KOLIBRI_HOME}"/options.ini
 [Deployment]
 STATIC_USE_SYMLINKS = 0
 EOF
+if [ "${EIB_KOLIBRI_DESKTOP_AUTH_PLUGIN_REGULAR_USERS_CAN_MANAGE_CONTENT}" = "true" ]; then
+    cat << EOF >> "${KOLIBRI_HOME}"/options.ini
+[DesktopAuth]
+REGULAR_USERS_CAN_MANAGE_CONTENT = True
+EOF
+fi
 
 kolibri plugin enable kolibri.plugins.app
 kolibri plugin enable kolibri_app_desktop_xdg_plugin
+kolibri plugin enable kolibri_desktop_auth_plugin
 
 for channel_id in ${EIB_KOLIBRI_INSTALL_CHANNELS}; do
   import_kolibri_channel "${channel_id}"


### PR DESCRIPTION
Add option for partners that wish to force Kolibri superadmin user for
regular system users.

If the option is set in the image INI file, it will be added to
Kolibri's options INI file.

https://phabricator.endlessm.com/T33035