### PR TITLE
Handle --localdir relative paths correctly

### DIFF
--- a/eos-image-builder
+++ b/eos-image-builder
@@ -23,21 +23,22 @@ from argparse import ArgumentParser
 import errno
 import fcntl
 import os
-import shutil
 import subprocess
 import sys
 import time
 
 MYDIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(1, os.path.join(MYDIR, 'lib'))
-import eib
+import eib  # noqa: E402
 
 LOCKTIMEOUT = 60
+
 
 def set_close_on_exec(fd):
     flags = fcntl.fcntl(fd, fcntl.F_GETFD)
     flags |= fcntl.FD_CLOEXEC
     fcntl.fcntl(fd, fcntl.F_SETFD, flags)
+
 
 def lock_builder(lockf, timeout):
     wait = timeout
@@ -64,6 +65,7 @@ def lock_builder(lockf, timeout):
     lockf.truncate()
     lockf.write('%d\n' % os.getpid())
     lockf.flush()
+
 
 # This option list must stay in sync with run-build. It's repeated here
 # so that the branch to checkout can be reliably determined.

--- a/eos-image-builder
+++ b/eos-image-builder
@@ -28,6 +28,7 @@ import sys
 import time
 
 MYDIR = os.path.dirname(os.path.realpath(__file__))
+RUN_BUILD = os.path.join(MYDIR, 'run-build')
 sys.path.insert(1, os.path.join(MYDIR, 'lib'))
 import eib  # noqa: E402
 
@@ -75,7 +76,7 @@ args = aparser.parse_args()
 
 # Shortcut to show the configuration without taking the lock.
 if args.show_config or args.show_apps:
-    exit(subprocess.call(['./run-build'] + sys.argv[1:]))
+    exit(subprocess.call([RUN_BUILD] + sys.argv[1:]))
 
 # Open the lock file a+ so it can be RW without truncating, but seek to
 # the beginning to either read or write the whole file.
@@ -91,4 +92,4 @@ with open(eib.LOCKFILE, 'a+') as lf:
     set_close_on_exec(lf.fileno())
 
     # Run the real builder from the checkout
-    subprocess.check_call(['./run-build'] + sys.argv[1:], cwd=MYDIR)
+    subprocess.check_call([RUN_BUILD] + sys.argv[1:])


### PR DESCRIPTION
The instructions in endless-image-config suggest you can do `/path/to/eos-image-builder --localdir .`, but that doesn't actually work when the working directory is changed in order to call `./run-build`. Once `run-build` is called the `--localdir` path is converted to absolute, but by then it's too late.