### PR TITLE
Kolibri provisioning eos4.0 backports

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -238,7 +238,7 @@ branding_subst_vars_add =
 app_version = 0.14.7
 app_desktop_xdg_plugin_version = 1.0.9
 
-automatic_provision = true
+automatic_provision = false
 automatic_provision_facility_name = Endless
 automatic_provision_superuser_name =
 automatic_provision_superuser_password =

--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -244,6 +244,11 @@ automatic_provision_superuser_name =
 automatic_provision_superuser_password =
 automatic_provision_preset = nonformal
 automatic_provision_landing_page = learn
+automatic_provision_learner_can_edit_username = false
+automatic_provision_learner_can_edit_name = false
+automatic_provision_learner_can_edit_password = false
+automatic_provision_learner_can_sign_up = false
+automatic_provision_allow_guest_access = false
 
 # Preloaded Kolibri channels
 #

--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -138,6 +138,7 @@ hooks_add =
   60-kolibri-content
   61-dconf-compile.chroot
   61-kolibri-content-install
+  62-kolibri-automatic-provision
   63-icon-grid
   70-flatpak-manifest
   70-ostree-manifest

--- a/hooks/image/61-kolibri-content-install
+++ b/hooks/image/61-kolibri-content-install
@@ -17,9 +17,15 @@ if [ "${EIB_KOLIBRI_AUTOMATIC_PROVISION}" = "true" ]; then
   "superusername": "${EIB_KOLIBRI_AUTOMATIC_PROVISION_SUPERUSER_NAME}",
   "superuserpassword": "${EIB_KOLIBRI_AUTOMATIC_PROVISION_SUPERUSER_PASSWORD}",
   "preset": "${EIB_KOLIBRI_AUTOMATIC_PROVISION_PRESET}",
-  "facility_settings": {},
+  "facility_settings": {
+    "learner_can_edit_username": ${EIB_KOLIBRI_AUTOMATIC_PROVISION_LEARNER_CAN_EDIT_USERNAME},
+    "learner_can_edit_name": ${EIB_KOLIBRI_AUTOMATIC_PROVISION_LEARNER_CAN_EDIT_NAME},
+    "learner_can_edit_password": ${EIB_KOLIBRI_AUTOMATIC_PROVISION_LEARNER_CAN_EDIT_PASSWORD},
+    "learner_can_sign_up": ${EIB_KOLIBRI_AUTOMATIC_PROVISION_LEARNER_CAN_SIGN_UP}
+  },
   "device_settings": {
     "landing_page": "${EIB_KOLIBRI_AUTOMATIC_PROVISION_LANDING_PAGE}",
+    "allow_guest_access": ${EIB_KOLIBRI_AUTOMATIC_PROVISION_ALLOW_GUEST_ACCESS},
     "allow_other_browsers_to_connect": 0
   }
 }

--- a/hooks/image/61-kolibri-content-install
+++ b/hooks/image/61-kolibri-content-install
@@ -8,27 +8,5 @@ fi
 KOLIBRI_CONTENT_DIR="${EIB_CONTENTDIR}/kolibri-content"
 
 mkdir -p "${OSTREE_VAR}"/lib/kolibri
+
 cp -rl "${KOLIBRI_CONTENT_DIR}" "${OSTREE_VAR}"/lib/kolibri/data
-
-if [ "${EIB_KOLIBRI_AUTOMATIC_PROVISION}" = "true" ]; then
-  cat <<EOF > "${OSTREE_VAR}"/lib/kolibri/data/automatic_provision.json
-{
-  "facility": "${EIB_KOLIBRI_AUTOMATIC_PROVISION_FACILITY_NAME}",
-  "superusername": "${EIB_KOLIBRI_AUTOMATIC_PROVISION_SUPERUSER_NAME}",
-  "superuserpassword": "${EIB_KOLIBRI_AUTOMATIC_PROVISION_SUPERUSER_PASSWORD}",
-  "preset": "${EIB_KOLIBRI_AUTOMATIC_PROVISION_PRESET}",
-  "facility_settings": {
-    "learner_can_edit_username": ${EIB_KOLIBRI_AUTOMATIC_PROVISION_LEARNER_CAN_EDIT_USERNAME},
-    "learner_can_edit_name": ${EIB_KOLIBRI_AUTOMATIC_PROVISION_LEARNER_CAN_EDIT_NAME},
-    "learner_can_edit_password": ${EIB_KOLIBRI_AUTOMATIC_PROVISION_LEARNER_CAN_EDIT_PASSWORD},
-    "learner_can_sign_up": ${EIB_KOLIBRI_AUTOMATIC_PROVISION_LEARNER_CAN_SIGN_UP}
-  },
-  "device_settings": {
-    "landing_page": "${EIB_KOLIBRI_AUTOMATIC_PROVISION_LANDING_PAGE}",
-    "allow_guest_access": ${EIB_KOLIBRI_AUTOMATIC_PROVISION_ALLOW_GUEST_ACCESS},
-    "allow_other_browsers_to_connect": 0
-  }
-}
-EOF
-fi
-

--- a/hooks/image/62-kolibri-automatic-provision
+++ b/hooks/image/62-kolibri-automatic-provision
@@ -1,0 +1,27 @@
+# Configure Kolibri automatic provisioning if enabled
+
+if [ "${EIB_KOLIBRI_AUTOMATIC_PROVISION}" != "true" ]; then
+  exit 0
+fi
+
+mkdir -p "${OSTREE_VAR}"/lib/kolibri/data
+
+cat <<EOF > "${OSTREE_VAR}"/lib/kolibri/data/automatic_provision.json
+{
+  "facility": "${EIB_KOLIBRI_AUTOMATIC_PROVISION_FACILITY_NAME}",
+  "superusername": "${EIB_KOLIBRI_AUTOMATIC_PROVISION_SUPERUSER_NAME}",
+  "superuserpassword": "${EIB_KOLIBRI_AUTOMATIC_PROVISION_SUPERUSER_PASSWORD}",
+  "preset": "${EIB_KOLIBRI_AUTOMATIC_PROVISION_PRESET}",
+  "facility_settings": {
+    "learner_can_edit_username": ${EIB_KOLIBRI_AUTOMATIC_PROVISION_LEARNER_CAN_EDIT_USERNAME},
+    "learner_can_edit_name": ${EIB_KOLIBRI_AUTOMATIC_PROVISION_LEARNER_CAN_EDIT_NAME},
+    "learner_can_edit_password": ${EIB_KOLIBRI_AUTOMATIC_PROVISION_LEARNER_CAN_EDIT_PASSWORD},
+    "learner_can_sign_up": ${EIB_KOLIBRI_AUTOMATIC_PROVISION_LEARNER_CAN_SIGN_UP}
+  },
+  "device_settings": {
+    "landing_page": "${EIB_KOLIBRI_AUTOMATIC_PROVISION_LANDING_PAGE}",
+    "allow_guest_access": ${EIB_KOLIBRI_AUTOMATIC_PROVISION_ALLOW_GUEST_ACCESS},
+    "allow_other_browsers_to_connect": 0
+  }
+}
+EOF


### PR DESCRIPTION
These are backports of #49 and #55 to the eos4.0 stable branch. I believe they're all appropriate for stable image builds since Kolibri and the relevant plugins have all been released (@dylanmccall correct me if I'm wrong).

https://phabricator.endlessm.com/T32885