### PR TITLE
Support config schema in local config dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,24 @@ The system and local configuration files are not typically used. They
 can allow for a permanent or temporary override for a particular host or
 build.
 
+Schema
+------
+
+The image builder configuration scheme is intentionally very flexible to
+allow building images with various combinations of attributes. That
+flexibility means that it's easy to initiate builds with unsupported
+settings. A configuration schema can be defined to help ensure specific
+keys are set or to limit their values to a supported set.
+
+The configuration schema is defined in `config/schema.ini` and
+`$localdir/config/schema.ini`. Schema files are INI formatted like the
+configuration itself. Sections and key names match the config files,
+with key suffixes as follows:
+
+ * `_required`: `true` means that the key must be set
+ * `_values`: the value, if set, must be within the space-separated list
+   of values here
+
 Merged options
 --------------
 

--- a/run-build
+++ b/run-build
@@ -462,6 +462,10 @@ class ImageBuilder(object):
         schema_file = os.path.join(self.configdir, 'schema.ini')
         schema = eib.ImageConfigParser()
         schema.read_config_file(schema_file, 'schema')
+        if self.local_configdir:
+            local_schema_file = os.path.join(self.local_configdir,
+                                             'schema.ini')
+            schema.read_config_file(local_schema_file, 'local_schema')
 
         for sect in schema.sections():
             for option, value in schema.items(sect):


### PR DESCRIPTION
While lightly used, the config schema can be useful to ensure options constrained to supported values. Currently this is only read from the eib config directory, but it should also be read from a local configuration directory. There it makes more sense as a local config directory is likely targeted to a much narrower scope and can better define what values are supported.

https://phabricator.endlessm.com/T33034