### PR TITLE
ImageBuildRoot: Disable buildroot apt cache handling

### DIFF
--- a/helpers/mmdebstrap-cleanup
+++ b/helpers/mmdebstrap-cleanup
@@ -4,15 +4,5 @@
 
 ROOT=${1:?No root directory supplied}
 
-for var in BUILDROOT_APT_CACHE; do
-    if [ ! -v "$var" ]; then
-        echo "error: Required variable $var not set" >&2
-        exit 1
-    fi
-done
-
 # Remove the temporary keyring path overrides
 rm -f "$ROOT/etc/apt/apt.conf.d/99keyring"
-
-# Update the persistent apt cache
-rsync -a --exclude=/partial /var/cache/apt/archives/ "$BUILDROOT_APT_CACHE/"

--- a/helpers/mmdebstrap-setup
+++ b/helpers/mmdebstrap-setup
@@ -4,7 +4,7 @@
 
 ROOT=${1:?No root directory supplied}
 
-for var in BUILDROOT_KEYRING BUILDROOT_APT_CACHE; do
+for var in BUILDROOT_KEYRING; do
     if [ ! -v "$var" ]; then
         echo "error: Required variable $var not set" >&2
         exit 1
@@ -30,6 +30,3 @@ cat > "$ROOT/etc/apt/apt.conf.d/99keyring" <<EOF
 Dir::Etc::Trusted "$BUILDROOT_KEYRING";
 Dir::Etc::TrustedParts "";
 EOF
-
-# Populate the apt cache from the persistent cache.
-rsync -a --exclude=/partial "$BUILDROOT_APT_CACHE/" /var/cache/apt/archives/

--- a/run-build
+++ b/run-build
@@ -88,13 +88,19 @@ class ImageBuildRoot(object):
         keyring = eib.get_keyring(config)
 
         # Wipe the apt cache directory if it's grown too large.
-        if os.path.exists(aptcache_dir):
-            aptcache_size = eib.disk_usage(aptcache_dir)
-            if aptcache_size >= aptcache_max_size:
-                log.info('Apt cache directory uses %d bytes, removing',
-                         aptcache_size)
-                shutil.rmtree(aptcache_dir)
-        os.makedirs(os.path.join(aptcache_dir), exist_ok=True)
+        #
+        # FIXME: This is currently commented because mmdebstrap throws
+        # an error if you seed /var/cache/apt/archives in the root
+        # before it runs. To make this work something like apt-cacher is
+        # needed to handle it at the HTTP level.
+        #
+        # if os.path.exists(aptcache_dir):
+        #     aptcache_size = eib.disk_usage(aptcache_dir)
+        #     if aptcache_size >= aptcache_max_size:
+        #         log.info('Apt cache directory uses %d bytes, removing',
+        #                  aptcache_size)
+        #         shutil.rmtree(aptcache_dir)
+        # os.makedirs(os.path.join(aptcache_dir), exist_ok=True)
 
         # Generate a sources list
         sources_args = {
@@ -123,7 +129,6 @@ class ImageBuildRoot(object):
         buildroot_env = os.environ.copy()
         buildroot_env.update({
             'BUILDROOT_KEYRING': keyring,
-            'BUILDROOT_APT_CACHE': aptcache_dir,
         })
         buildroot_cmd = (
             'mmdebstrap',


### PR DESCRIPTION
The mmdebstrap hooks were doing entirely the wrong thing by syncing
between the image builder's apt cache and the **system's**
`/var/cache/apt/archives`. That's both wrong and pointless.

Changing that to sync into the buildroot's apt archives makes
`mmdebstrap` throw an error. Apparently it uses the contents of
`/var/cache/apt/archives` to figure out what to install after telling
apt to download packages, so it requires the directory to be empty when
it starts.

To bring this back, something like apt-cacher that works at the network
level is needed.

Fixes: #63

This should be backported to the eos4.0 branch.