### PR TITLE
kolibri: Use our content CDN by default

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -253,6 +253,11 @@ automatic_provision_learner_can_edit_password = false
 automatic_provision_learner_can_sign_up = false
 automatic_provision_allow_guest_access = false
 
+# By default, kolibri uses https://studio.learningequality.org as the
+# base content URL. Offload that to our own CDN during the image build.
+# If cleared, the upstream default will be used.
+central_content_base_url = https://kolibri-content.endlessos.org
+
 regular_users_can_manage_content = false
 
 # Preloaded Kolibri channels

--- a/hooks/image/60-kolibri-content
+++ b/hooks/image/60-kolibri-content
@@ -4,6 +4,12 @@ if [ -z "${EIB_KOLIBRI_INSTALL_CHANNELS}" ]; then
   exit 0
 fi
 
+# Use a separate content URL if configured.
+if [ -n "${EIB_KOLIBRI_CENTRAL_CONTENT_BASE_URL}" ]; then
+  KOLIBRI_CENTRAL_CONTENT_BASE_URL="${EIB_KOLIBRI_CENTRAL_CONTENT_BASE_URL}"
+  export KOLIBRI_CENTRAL_CONTENT_BASE_URL
+fi
+
 # Do not create symlinks for static files inside the image builder.
 export KOLIBRI_STATIC_USE_SYMLINKS=0
 


### PR DESCRIPTION
To offload our Learning Equality's CDN, we've setup our own CDN in front
of it at https://kolibri-content.endlessos.org. Import channels using
that as the base URL and configure deployments to use it. The
configuration can be cleared to go back to the default URL.

https://phabricator.endlessm.com/T30950