### PR TITLE
image: Specify bootloader to ostree

### DIFF
--- a/stages/eib_image
+++ b/stages/eib_image
@@ -60,9 +60,14 @@ if [[ "${EIB_ARCH}" == "armhf" ]] || [[ "${EIB_ARCH}" == "arm64" ]]; then
   # Empty uEnv.txt otherwise ostree gets upset
   > "${BOOT}"/loader/uEnv.txt
   ln -s loader/uEnv.txt "${BOOT}"/uEnv.txt
+  ostree --repo="${REPOPATH}" config set sysroot.bootloader uboot
 else
   # Assume grub for all other architectures
   mkdir -p "${BOOT}"/grub
+
+  # Configure the ostree bootloader to none so it only makes BLS entries
+  # and doesn't try to update grub.cfg.
+  ostree --repo="${REPOPATH}" config set sysroot.bootloader none
 fi
 
 # Platform dependent boot arguments


### PR DESCRIPTION
Until now we've relied on ostree's automatic bootloader detection, which
relies on the presence of certain files to determine which bootloader is
in use. Instead we should specify what bootloader to use so the decision
is unambiguous.

When grub is the bootloader, we actually don't want to use ostree's grub
integration. That tries to update grub.cfg whereas we just want it to
update the BLS entries since our grub can read those and our grub.cfg
doesn't support updating. This will help us drop an ugly downstream hack
that makes the ostree grub bootloader integration do nothing.

https://phabricator.endlessm.com/T33364