### PR TITLE
Kolibri importcontent fixes backports

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -237,9 +237,9 @@ branding_fbe_config = ${build:datadir}/branding/gnome-initial-setup/default/gnom
 branding_subst_vars_add =
 
 [kolibri]
-app_version = 0.14.7
-app_desktop_xdg_plugin_version = 1.0.9
-desktop_auth_plugin_version = 0.0.6
+app_version = 0.15.2
+app_desktop_xdg_plugin_version = 1.1.4
+desktop_auth_plugin_version = 0.0.7
 
 automatic_provision = false
 automatic_provision_facility_name = Endless

--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -237,7 +237,7 @@ branding_fbe_config = ${build:datadir}/branding/gnome-initial-setup/default/gnom
 branding_subst_vars_add =
 
 [kolibri]
-app_version = 0.15.2
+app_version = 0.15.3
 app_desktop_xdg_plugin_version = 1.1.4
 desktop_auth_plugin_version = 0.0.7
 

--- a/hooks/image/60-kolibri-content
+++ b/hooks/image/60-kolibri-content
@@ -12,7 +12,16 @@ import_kolibri_channel()
   local channel_id=$1
   local channel_include_node_ids_var="EIB_KOLIBRI_${channel_id^^}_INCLUDE_NODE_IDS"
   local channel_exclude_node_ids_var="EIB_KOLIBRI_${channel_id^^}_EXCLUDE_NODE_IDS"
-  local importcontent_opts=()
+  local importcontent_opts=(
+    # Normally importcontent ignores download errors. Make it fail so we
+    # can be sure we've fully provisioned channels.
+    --fail-on-error
+  )
+  local importcontent_network_opts=(
+    # The default timeout is 60 seconds, but downloading can be slow
+    # when objects aren't in our content CDN yet.
+    --timeout 300
+  )
 
   if [ -n "${!channel_include_node_ids_var}" ]; then
     importcontent_include_nodes=$(echo "${!channel_include_node_ids_var}" | xargs | tr -s ' ' ',')
@@ -25,7 +34,8 @@ import_kolibri_channel()
   fi
 
   kolibri manage importchannel network "${channel_id}"
-  kolibri manage importcontent ${importcontent_opts[@]} network "${channel_id}"
+  kolibri manage importcontent "${importcontent_opts[@]}" \
+    network "${importcontent_network_opts[@]}" "${channel_id}"
 }
 
 # Needs to be kept in sync with hooks/image/61-kolibri-content-install


### PR DESCRIPTION
Backport the kolibri importcontent fixes from master to make it reliable.

https://phabricator.endlessm.com/T33363
https://phabricator.endlessm.com/T33365