### PR TITLE
config: Temporarily bypass our Kolibri CDN

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -256,7 +256,9 @@ automatic_provision_allow_guest_access = false
 # By default, kolibri uses https://studio.learningequality.org as the
 # base content URL. Offload that to our own CDN during the image build.
 # If cleared, the upstream default will be used.
-central_content_base_url = https://kolibri-content.endlessos.org
+# NOTE: we are temporarily pointing directy to Kolibri Studio while we fix
+# some issues with our CDN not being able to get some content.
+central_content_base_url =
 
 regular_users_can_manage_content = false
 


### PR DESCRIPTION
Our CDN is having some issues with downloading content from Kolibri
Studio, which is causing problems with objects being unavailable. We are
reverting back to downloading directly from Kolibri Studio while those
issues get sorted.

https://phabricator.endlessm.com/T33704