### PR TITLE
Fail build if Flatpaks are marked eol-rebase

### DIFF
--- a/lib/eibflatpak.py
+++ b/lib/eibflatpak.py
@@ -742,6 +742,15 @@ class FlatpakManager(object):
         # Dict of FlatpakInstallRefs needed for installation keyed by
         # the ref string.
         self.install_refs = {}
+        eol_refs = []
+        eol_rebase_refs = []
+
+        def _check_eol(full_ref):
+            if full_ref.remote_ref.get_eol():
+                eol_refs.append(full_ref)
+
+            if full_ref.remote_ref.get_eol_rebase():
+                eol_rebase_refs.append(full_ref)
 
         # Get required apps and runtimes
         for remote in self.remotes.values():
@@ -754,6 +763,7 @@ class FlatpakManager(object):
                     raise FlatpakError('Could not find app', app, 'in',
                                        remote.name)
                 self._check_excluded(full_ref)
+                _check_eol(full_ref)
                 logger.info('Adding app %s from %s', full_ref.ref,
                             remote.name)
                 self.install_refs[full_ref.ref] = FlatpakInstallRef(
@@ -765,6 +775,7 @@ class FlatpakManager(object):
                     raise FlatpakError('Could not find runtime',
                                        runtime, 'in', remote.name)
                 self._check_excluded(full_ref)
+                _check_eol(full_ref)
                 logger.info('Adding runtime %s from %s', full_ref.ref,
                             remote.name)
                 self.install_refs[full_ref.ref] = FlatpakInstallRef(
@@ -791,6 +802,7 @@ class FlatpakManager(object):
                     except FlatpakError as e:
                         raise FlatpakError("Can't install runtime for ref",
                                            full_ref.ref, "-", e.msg)
+                    _check_eol(runtime)
                     logger.info('Adding %s runtime %s from %s',
                                 full_ref.ref, runtime.ref,
                                 runtime.remote.name)
@@ -819,6 +831,7 @@ class FlatpakManager(object):
                             logger.info("Excluding %s related ref: %s",
                                         full_ref.ref, e)
                             continue
+                        _check_eol(match)
                         logger.info('Adding %s related ref %s from %s',
                                     full_ref.ref, related_ref,
                                     match.remote.name)
@@ -833,6 +846,30 @@ class FlatpakManager(object):
                         install_match.subpaths = subpaths
 
                 checked_refs.add(full_ref.ref)
+
+        for full_ref in eol_refs:
+            logger.warn(
+                "%s in %s is marked as EOL: %s",
+                full_ref.ref,
+                full_ref.remote.name,
+                full_ref.remote_ref.get_eol(),
+            )
+
+        for full_ref in eol_rebase_refs:
+            logger.error(
+                "%s in %s is marked as EOL, superseded by %s",
+                full_ref.ref,
+                full_ref.remote.name,
+                full_ref.remote_ref.get_eol_rebase(),
+            )
+
+        # TODO: optionally make plain EOL fatal? make this optionally non-fatal?
+        if eol_rebase_refs:
+            raise FlatpakError(
+                "Refusing to build image containing Flatpaks marked as eol-rebase:",
+                ", ".join(full_ref.ref for full_ref in eol_rebase_refs),
+            )
+
 
     @staticmethod
     def _subpaths_to_subdirs(subpaths):


### PR DESCRIPTION
Example output:

    + 13:25:17 WARNING eibflatpak: app/com.github.lainsce.notejot/x86_64/stable in flathub is marked as EOL: The application has been renamed to Notejot (io.github.lainsce.Notejot)
    + 13:25:17 WARNING eibflatpak: runtime/org.gnome.Platform/x86_64/3.28 in flathub is marked as EOL: The GNOME 3.28 runtime is no longer supported and does not receive security updates. Please ask your application developer to migrate to a supported platform.
    + 13:25:17 WARNING eibflatpak: runtime/org.freedesktop.Platform/x86_64/19.08 in flathub is marked as EOL: The Freedesktop SDK 19.08 runtime is no longer supported as of September 1, 2021. Please ask your application developer to migrate to a supported version
    + 13:25:17 WARNING eibflatpak: runtime/com.github.lainsce.notejot.Locale/x86_64/stable in flathub is marked as EOL: The application has been renamed to Notejot (io.github.lainsce.Notejot)
    + 13:25:17 WARNING eibflatpak: runtime/org.freedesktop.Platform.VAAPI.Intel/x86_64/1.6 in flathub is marked as EOL: The Freedesktop 1.6 runtime is no longer supported and does not receive security updates. Please ask your application developer to migrate to a supported runtime.
    + 13:25:17 WARNING eibflatpak: runtime/org.gnome.Platform.Locale/x86_64/3.28 in flathub is marked as EOL: The GNOME 3.28 runtime is no longer supported and does not receive security updates. Please ask your application developer to migrate to a supported platform.
    + 13:25:17 WARNING eibflatpak: runtime/org.freedesktop.Platform.GL.default/x86_64/19.08 in flathub is marked as EOL: The Freedesktop SDK 19.08 runtime is no longer supported as of September 1, 2021. Please ask your application developer to migrate to a supported version
    + 13:25:17 WARNING eibflatpak: runtime/org.freedesktop.Platform.Locale/x86_64/19.08 in flathub is marked as EOL: The Freedesktop SDK 19.08 runtime is no longer supported as of September 1, 2021. Please ask your application developer to migrate to a supported version
    + 13:25:17 WARNING eibflatpak: runtime/org.freedesktop.Platform.VAAPI.Intel/x86_64/19.08 in flathub is marked as EOL: The Freedesktop SDK 19.08 runtime is no longer supported as of September 1, 2021. Please ask your application developer to migrate to a supported version
    + 13:25:17 ERROR eibflatpak: app/com.github.lainsce.notejot/x86_64/stable in flathub is marked as EOL, superseded by app/io.github.lainsce.Notejot/x86_64/stable
    + 13:25:17 ERROR eibflatpak: runtime/com.github.lainsce.notejot.Locale/x86_64/stable in flathub is marked as EOL, superseded by runtime/io.github.lainsce.Notejot.Locale/x86_64/stable
    Traceback (most recent call last):
      File "/sysroot/home/wjt/src/endlessm/eos-image-builder/run-build", line 611, in <module>
        main()
      File "/sysroot/home/wjt/src/endlessm/eos-image-builder/run-build", line 608, in main
        builder.run()
      File "/sysroot/home/wjt/src/endlessm/eos-image-builder/run-build", line 556, in run
        applist.show_apps(self.config,
      File "/sysroot/home/wjt/src/endlessm/eos-image-builder/lib/applist.py", line 268, in show_apps
        manager.resolve_refs()
      File "/sysroot/home/wjt/src/endlessm/eos-image-builder/lib/eibflatpak.py", line 868, in resolve_refs
        raise FlatpakError(
    eibflatpak.FlatpakError: Refusing to build image with eol-rebase refs: app/com.github.lainsce.notejot/x86_64/stable, runtime/com.github.lainsce.notejot.Locale/x86_64/stable

In a perfect world we would also fail the build if anything is marked
EOL, without replacement. However this is not practical for a few
reasons:

1. Several of our first-party apps use EOLed runtimes
2. All of our first-party runtimes drag in EOLed extensions because they
   are based on EOLed runtimes
3. There may be cases where we want to knowingly include an EOLed app

By contrast, if an app is marked eol-rebase, we can quickly update the
configuration to point to its new name: the same substitution will be
made by regular Flatpak app updates anyway. Making the build fail is the
simplest fway to make us make this change. We take care to batch up all
the changes that need to be made before failing so that the luckless
release engineer does not need to play whack-a-mole, one app at a time.

https://phabricator.endlessm.com/T28037
