### PR TITLE
Preinstall Firefox and add to favourites

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -207,6 +207,7 @@ timezone =
 # dconf overrides. Each of the elements of this list should be a keyfile in the
 # format explained at https://wiki.gnome.org/Projects/dconf/SystemAdministrators
 settings_add =
+  ${build:datadir}/settings/misc/firefox-in-favorites
 
 # dconf keys to lock
 settings_locks_add =
@@ -484,6 +485,7 @@ apps_add_mandatory =
   org.gnome.font-viewer
   org.gnome.gedit
   org.libreoffice.LibreOffice
+  org.mozilla.firefox
 apps_add =
   cc.arduino.arduinoide
   com.endlessm.photos

--- a/data/settings/misc/firefox-in-favorites
+++ b/data/settings/misc/firefox-in-favorites
@@ -1,0 +1,2 @@
+[org/gnome/shell]
+favorite-apps=['org.gnome.Software.desktop', 'org.mozilla.firefox.desktop', 'org.chromium.Chromium.desktop', 'org.gnome.Nautilus.desktop']


### PR DESCRIPTION
This is not for a release; it is for remote usability testing. Firefox's
screensharing UI is smoother than Chromium's on Wayland and its "you are
sharing your screen and webcam" popover does not sit at the bottom of
the screen, hiding the dock.

https://phabricator.endlessm.com/T33758