### PR TITLE
config: arm64: Remove Blender which is not available on arm64

### DIFF
--- a/config/arch/arm64.ini
+++ b/config/arch/arm64.ini
@@ -17,6 +17,7 @@ apps_del =
   edu.mit.Scratch
   cc.arduino.arduinoide
   com.endlessnetwork.aqueducts
+  com.endlessnetwork.blendertutorials
   com.endlessnetwork.dragonsapprentice
   com.endlessnetwork.fablemaker
   com.endlessnetwork.frogsquash
@@ -27,3 +28,4 @@ apps_del =
   com.endlessnetwork.whitehouse
   io.atom.Atom
   io.lmms.LMMS
+  org.blender.Blender


### PR DESCRIPTION
The Blender flatpak builds failed on arm64 now. See the ticket "Support
aarch64 architecture". [1] So, drop Blender on arm64 platforms.

[1]: https://github.com/flathub/org.blender.Blender/issues/99

https://phabricator.endlessm.com/T33749