### PR TITLE
Improve OVF generation

### DIFF
--- a/helpers/generate-ovf-files
+++ b/helpers/generate-ovf-files
@@ -6,12 +6,17 @@ Generate Open Virtualization Format package for Endless OS
 '''
 
 import argparse
+import eib
+import logging
 import os
+import shlex
 import subprocess
 import uuid
 from xml.dom import minidom
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element, SubElement
+
+logger = logging.getLogger(os.path.basename(__file__))
 
 class OVFGenerator:
     # System configuration
@@ -40,7 +45,7 @@ class OVFGenerator:
 
     def __run(self, cmd, shell=False):
         '''Run cmd locally.'''
-        print('# {}'.format(cmd))
+        logger.info('# %s', shlex.join(cmd))
 
         return subprocess.check_output(cmd, shell=shell)
 
@@ -329,6 +334,8 @@ class OVFGenerator:
 
 
 def main():
+    eib.setup_logging()
+
     parser = argparse.ArgumentParser(
     description='Import an EOS disk image into OVF format as a VM'
                 'with approiate system configuration.')

--- a/helpers/generate-ovf-files
+++ b/helpers/generate-ovf-files
@@ -294,9 +294,8 @@ class OVFGenerator:
         # Output OVF description file
         mydata = ElementTree.tostring(top, 'utf-8')
         reparsed = minidom.parseString(mydata)
-        ovfile = open(self.__trim_file_type(pathname)+'.ovf', 'w')
-        ovfile.write(reparsed.toprettyxml(indent='    '))
-        ovfile.close()
+        with open(self.__trim_file_type(pathname)+'.ovf', 'w') as ovfile:
+            ovfile.write(reparsed.toprettyxml(indent='    '))
 
     def __archive_to_zip(self, out_path=None):
         ovf_file = self.__trim_file_type(self.IMAGE_FILE) + '.ovf'
@@ -314,9 +313,8 @@ class OVFGenerator:
         self.__run(['zip', '--junk-paths', zip_file, ovf_file, vmdk_file, mf_file])
 
         uncompressed_size = os.stat(ovf_file).st_size + os.stat(vmdk_file).st_size + os.stat(mf_file).st_size
-        size_file = open(zip_file + '.size', 'w')
-        size_file.write(str(uncompressed_size))
-        size_file.close()
+        with open(zip_file + '.size', 'w') as size_file:
+            size_file.write(str(uncompressed_size))
 
     def __del__(self):
         # Remove left-over artifacts

--- a/helpers/generate-ovf-files
+++ b/helpers/generate-ovf-files
@@ -310,7 +310,11 @@ class OVFGenerator:
             self.__run(["sha256sum", "--tag", ovf_file, vmdk_file],
                        stdout=manifest)
 
-        self.__run(['zip', '--junk-paths', zip_file, ovf_file, vmdk_file, mf_file])
+        # Compress the disk image itself in parallel:
+        with open(zip_file, "w") as f:
+            self.__run(["pigz", "--zip", "--stdout", "--keep", vmdk_file], stdout=f)
+        # Add the other, smaller files to the archive:
+        self.__run(['zip', '--junk-paths', zip_file, ovf_file, mf_file])
 
         uncompressed_size = os.stat(ovf_file).st_size + os.stat(vmdk_file).st_size + os.stat(mf_file).st_size
         with open(zip_file + '.size', 'w') as size_file:

--- a/helpers/generate-ovf-files
+++ b/helpers/generate-ovf-files
@@ -334,7 +334,7 @@ def main():
 
     parser = argparse.ArgumentParser(
     description='Import an EOS disk image into OVF format as a VM'
-                'with approiate system configuration.')
+                'with appropriate system configuration.')
     parser.add_argument('-c', '--cpus', type=int, required=False,
                         help='number of virtual CPUs (default 1)')
     parser.add_argument('-m', '--memory', type=int, required=False,

--- a/helpers/generate-ovf-files
+++ b/helpers/generate-ovf-files
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3 -u
 # -*- coding: utf-8 -*-
 
 '''

--- a/helpers/generate-ovf-files
+++ b/helpers/generate-ovf-files
@@ -43,11 +43,11 @@ class OVFGenerator:
         self.VM_UUID = str(uuid.uuid4())
         self.VOL_UUID = str(uuid.uuid4())
 
-    def __run(self, cmd, shell=False):
+    def __run(self, cmd, **kwargs):
         '''Run cmd locally.'''
         logger.info('# %s', shlex.join(cmd))
 
-        return subprocess.check_output(cmd, shell=shell)
+        return subprocess.check_call(cmd, **kwargs)
 
     def __trim_file_type(self, filename):
         if filename.endswith('.img.xz') or \
@@ -307,11 +307,9 @@ class OVFGenerator:
         else:
             zip_file = self.__trim_file_type(self.IMAGE_FILE) + '.ovf.zip'
 
-        manifest = open(mf_file, 'w')
-        for f in ovf_file, vmdk_file:
-            digest = self.__run(['openssl', 'sha256', '-r', f]).decode('utf-8').split()[0]
-            manifest.write('SHA256(' + os.path.basename(f) + ')= ' + digest + '\n')
-        manifest.close()
+        with open(mf_file, 'w') as manifest:
+            self.__run(["sha256sum", "--tag", ovf_file, vmdk_file],
+                       stdout=manifest)
 
         self.__run(['zip', '--junk-paths', zip_file, ovf_file, vmdk_file, mf_file])
 


### PR DESCRIPTION
The meat is in the topmost commit: generate-ovf-files: Compress vmdk with pigz

'zip' cannot compress in parallel. 'pigz', which we already use elsewhere in eos-image-builder, can. It has a '--zip' flag to emit a ZIP file.

The rest is cleanup, though the logging change should make it possible to actually check what is taking time during this script.

In last night's master base image build, 00:03:30 - 00:12:56 was create-vm-image, i.e. 9m 26s.

https://phabricator.endlessm.com/T33762

