### PR TITLE
Temporarily install no apps or runtimes from Flathub

### DIFF
--- a/config/arch/arm64.ini
+++ b/config/arch/arm64.ini
@@ -7,6 +7,11 @@ enable = false
 boot_zip = false
 iso = false
 
+# Temporarily don't complain about missing mandatory apps from Flathub
+# https://phabricator.endlessm.com/T33827
+hooks_del =
+  60-flatpak-autoinstall-counters.chroot
+
 [flatpak-remote-flathub]
 # These extensions are not available for arm64
 # https://gitlab.com/freedesktop-sdk/openh264-extension/-/issues/2
@@ -29,3 +34,14 @@ apps_del =
   io.atom.Atom
   io.lmms.LMMS
   org.blender.Blender
+
+# Temporarily install no apps or runtimes from Flathub
+# https://phabricator.endlessm.com/T33827
+runtimes =
+apps =
+
+[flatpak-remote-flathub-beta]
+# Temporarily install no apps or runtimes from Flathub
+# https://phabricator.endlessm.com/T33827
+runtimes =
+apps =


### PR DESCRIPTION
Flathub removed aarch64 refs from the main summary (which hit the 10MB
limit). They are still accessible in the "sub-summary" which (lib)flatpak
knows how to use. Sadly eibflatpak.py bypasses libflatpak and attempts
to use the libostree API directly to pull Flatpak refs; libostree does
not know about sub-summaries so this fails.

https://phabricator.endlessm.com/T33827
