### PR TITLE
config: Update kolibri to 0.15.7

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -237,7 +237,7 @@ branding_fbe_config = ${build:datadir}/branding/gnome-initial-setup/default/gnom
 branding_subst_vars_add =
 
 [kolibri]
-app_version = 0.15.3
+app_version = 0.15.7
 app_desktop_xdg_plugin_version = 1.1.4
 desktop_auth_plugin_version = 0.0.7
 


### PR DESCRIPTION
This contains a couple fixes for `importcontent` to ensure it reliably errors when it cannot download content files.

https://phabricator.endlessm.com/T33363