### PR TITLE
Only remove flathub-beta arm64 apps on master

### DIFF
--- a/config/arch/arm64.ini
+++ b/config/arch/arm64.ini
@@ -39,9 +39,3 @@ apps_del =
 # https://phabricator.endlessm.com/T33827
 runtimes =
 apps =
-
-[flatpak-remote-flathub-beta]
-# Temporarily install no apps or runtimes from Flathub
-# https://phabricator.endlessm.com/T33827
-runtimes =
-apps =

--- a/config/branch-arch/master-arm64.ini
+++ b/config/branch-arch/master-arm64.ini
@@ -1,0 +1,5 @@
+[flatpak-remote-flathub-beta]
+# Temporarily install no apps or runtimes from Flathub
+# https://phabricator.endlessm.com/T33827
+runtimes =
+apps =


### PR DESCRIPTION
In a80916f / 82122a2 "Temporarily install no apps or runtimes from
Flathub" I explicitly set [flatpak-remote-flathub-beta] apps and
runtimes to empty list on any arm64 build. However, flathub-beta is only
enabled on master builds. As a result, stable builds failed:

    Traceback (most recent call last):
      File "/tmp/image-build-WJso41ligR/eos-image-builder/hooks/content/50-flatpak", line 57, in <module>
        manager = eibflatpak.FlatpakManager(installation, config=config,
      File "/tmp/image-build-WJso41ligR/eos-image-builder/lib/eibflatpak.py", line 547, in __init__
        self.remotes[name] = FlatpakRemote(self, name,
      File "/tmp/image-build-WJso41ligR/eos-image-builder/lib/eibflatpak.py", line 197, in __init__
        raise FlatpakError('No URL defined for remote', self.name)
    eibflatpak.FlatpakError: No URL defined for remote flathub-beta

Instead, only set these for master arm64 builds.

https://phabricator.endlessm.com/T33827
