### PR TITLE
config: arm64: Drop finance and resume temporarily

### DIFF
--- a/config/arch/arm64.ini
+++ b/config/arch/arm64.ini
@@ -21,6 +21,8 @@ runtimes_del =
 apps_del =
   edu.mit.Scratch
   cc.arduino.arduinoide
+  com.endlessm.finance
+  com.endlessm.resume
   com.endlessnetwork.aqueducts
   com.endlessnetwork.blendertutorials
   com.endlessnetwork.dragonsapprentice


### PR DESCRIPTION
The arm64 en images built failed, because failed to pull 'runtime/org.gnome.Platform.Locale/aarch64/3.28' from flathub. Besides, current com.endlessm.finance and com.endlessm.resume depend on runtime org.gnome.Platform//3.28. Here are two root causes:

* 'runtime/org.gnome.Platform.Locale/aarch64/3.28' does not exist on flathub anymore. This is tracked by "Move Resume & Finance/My Budget apps to modern tech stack, T33859".
* The ticket "T33827: Image builder can't install arm64 flatpaks from Flathub".

So, drop finance and resume from arm64 images temporarily.

https://phabricator.endlessm.com/T33876