### PR TITLE
config: arm64: Drop finance and resume from eos-apps temporarily

### DIFF
--- a/config/arch/arm64.ini
+++ b/config/arch/arm64.ini
@@ -12,6 +12,13 @@ iso = false
 hooks_del =
   60-flatpak-autoinstall-counters.chroot
 
+# Temporarily drop finance and resume from arm64 images
+# https://phabricator.endlessm.com/T33876#951709
+[flatpak-remote-eos-apps]
+apps_del =
+  com.endlessm.finance
+  com.endlessm.resume
+
 [flatpak-remote-flathub]
 # These extensions are not available for arm64
 # https://gitlab.com/freedesktop-sdk/openh264-extension/-/issues/2
@@ -21,8 +28,6 @@ runtimes_del =
 apps_del =
   edu.mit.Scratch
   cc.arduino.arduinoide
-  com.endlessm.finance
-  com.endlessm.resume
   com.endlessnetwork.aqueducts
   com.endlessnetwork.blendertutorials
   com.endlessnetwork.dragonsapprentice


### PR DESCRIPTION
We have tried to drop finance and resume by the commit 392c15aa7fbb ("config: arm64: Drop finance and resume temporarily"). However, they are the apps of "eos-apps", not "flathub". This commit drops finance and resume from the correct source: eos-apps.

Fixes: 392c15aa7fbb config: arm64: Drop finance and resume temporarily

https://phabricator.endlessm.com/T33876