### PR TITLE
config: drop Rhythmbox from default config

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -478,7 +478,6 @@ apps_add_mandatory =
   org.gnome.Contacts
   org.gnome.FileRoller
   org.gnome.Logs
-  org.gnome.Rhythmbox3
   org.gnome.Totem
   org.gnome.Shotwell
   org.gnome.font-viewer
@@ -505,6 +504,7 @@ apps_add =
   org.blender.Blender
   org.gimp.GIMP
   org.gnome.Gnote
+  org.gnome.Rhythmbox3
   org.gnome.Weather
   org.inkscape.Inkscape
   org.kde.gcompris


### PR DESCRIPTION
EOS is going to switch from Rhythmbox to GNOME Music as default music player. So, drop Rhythmbox from the default config.

https://phabricator.endlessm.com/T34075