### PR TITLE
kolibri: Retry if importing content fails

### DIFF
--- a/hooks/image/60-kolibri-content
+++ b/hooks/image/60-kolibri-content
@@ -40,7 +40,8 @@ import_kolibri_channel()
   fi
 
   kolibri manage importchannel network "${channel_id}"
-  kolibri manage importcontent "${importcontent_opts[@]}" \
+  EIB_RETRY_ATTEMPTS=2 EIB_RETRY_INTERVAL=30 eib_retry \
+    kolibri manage importcontent "${importcontent_opts[@]}" \
     network "${importcontent_network_opts[@]}" "${channel_id}"
 }
 


### PR DESCRIPTION
We see sporadic failures to import random pieces of content, due to the
Kolibri server returning something with the wrong checksum. (This is
believed to be the CDN serving an error, possibly a rate-limiting
error.) Typically, if we rerun the build, the error does not recur for
the same content file.

It is sad to fail a multi-hour, multi-hundred-gigabyte image build due
to a single broken content item. Add a retry loop around the import
function to try to recover.

https://phabricator.endlessm.com/T34149
