### PR TITLE
Use host ostree as localcache repo

### DIFF
--- a/run-build
+++ b/run-build
@@ -95,11 +95,23 @@ class ImageBuildRoot(object):
         repo_path = config['ostree']['repodir']
         remote = config['ostree']['remote']
         ref = config['ostree']['ref']
+
+        # If we are on an OSTree system, use the system repo as an additional cache.
+        # In the case of an Endless OS developer system booted into the same or similar
+        # ref as we are building an image of, this saves pulling over the network. In
+        # other cases it is harmless.
+        system_ostree_repo = '/ostree/repo'
+        if os.path.isdir(system_ostree_repo):
+            extra_pull_args = ['--localcache-repo', system_ostree_repo]
+        else:
+            extra_pull_args = []
+
         log.info(f'Pulling OSTree ref {remote}:{ref}')
         eib.retry(subprocess.check_call, [
             'ostree',
             f'--repo={repo_path}',
             'pull',
+            *extra_pull_args,
             remote,
             ref,
         ])


### PR DESCRIPTION
When running the image builder on Endless OS, there is a high chance that the host system will be running a similar, if not identical, OSTree commit to the one being built into the image. In my case, I run master and update essentially every morning, so running the image builder with its default arguments will use the same OSTree as is booted.

`ostree pull` supports a `--localcache-repo PATH` argument:

> Like git's clone --reference. Reuse the provided OSTree repo as a
> local object cache when doing HTTP fetches.

In this patch, we bind-mount the host's /ostree/repo into the buildroot, if it exists. The bind-mount is made read-only to reduce the risk that a bug in the image builder will mess up the host system.

This is obviously a hack but I thought I'd give it a try and it seems to make the build run somewhat faster locally. Of course from the second build on any given day it has no effect because the image builder's cache has the OS cached, so maybe it is not worthwhile. So this PR is more of an RFC.