### PR TITLE
image: Fix 00-keyboard.conf file generation

### DIFF
--- a/hooks/image/50-xkb-layout.chroot
+++ b/hooks/image/50-xkb-layout.chroot
@@ -19,7 +19,7 @@ if [ -n "${EIB_IMAGE_XKB_LAYOUT}" ]; then
 		EOF
 	fi
 
-	cat <<- EOF > ${TARGET_PATH}/00-keyboard.conf
+	cat <<- EOF >> ${TARGET_PATH}/00-keyboard.conf
 	EndSection
 	EOF
 


### PR DESCRIPTION
It accidentally overrode the entire file with a single EndSection instead of appending it. Fix it.

https://phabricator.endlessm.com/T34066