### PR TITLE
kolibri: Retry importcontent on error (eos4.0)

### DIFF
--- a/hooks/image/60-kolibri-content
+++ b/hooks/image/60-kolibri-content
@@ -40,7 +40,8 @@ import_kolibri_channel()
   fi
 
   kolibri manage importchannel network "${channel_id}"
-  kolibri manage importcontent "${importcontent_opts[@]}" \
+  EIB_RETRY_ATTEMPTS=2 EIB_RETRY_INTERVAL=30 eib_retry \
+    kolibri manage importcontent "${importcontent_opts[@]}" \
     network "${importcontent_network_opts[@]}" "${channel_id}"
 }
 


### PR DESCRIPTION
We see sporadic failures to import random pieces of content, due to the Kolibri server returning something with the wrong checksum. (This is believed to be the CDN serving an error, possibly a rate-limiting error.) Typically, if we rerun the build, the error does not recur for the same content file.

It is sad to fail a multi-hour, multi-hundred-gigabyte image build due to a single broken content item. Retry `kolibri manage importcontent` once, after a short pause, in hope of recovering in this case.

https://phabricator.endlessm.com/T34149
(cherry picked from commit 6eb5b59f89612006d8634e1cb3687caca47cb0cb)