### PR TITLE
config: Set eos-runtimes remote to use new repo URL

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -457,8 +457,8 @@ apps_add =
   com.endlessm.resume
 
 [flatpak-remote-eos-runtimes]
-url = ${ostree:prod_pull_repo_url}/eos
-deploy_url = ${ostree:prod_deploy_repo_url}/eos
+url = ${ostree:prod_pull_repo_url}/eos-runtimes
+deploy_url = ${ostree:prod_deploy_repo_url}/eos-runtimes
 
 [flatpak-remote-eos-sdk]
 url = ${ostree:prod_pull_repo_url}/eos-sdk


### PR DESCRIPTION
The legacy runtimes have been copied out of the eos repo to a new eos-runtimes repo so that it can be treated as a pure flatpak repo. This starts a long process where eventually we can remove the legacy runtimes from the eos repo and treat it as a pure ostree repo.

https://phabricator.endlessm.com/T33445