### PR TITLE
buildscript: Declare repo as a git safe directory

### DIFF
--- a/buildscript
+++ b/buildscript
@@ -21,6 +21,10 @@ done
 # Change back to the source directory since we've chrooted.
 cd "${EIB_SRCDIR}"
 
+# Declare this as a safe git directory inside the build root since this
+# is running as root and the repo may be owned by a different user.
+git config --system --add safe.directory "${EIB_SRCDIR}"
+
 # Make sure to find our stage scripts and python library
 export PATH="${EIB_SRCDIR}/stages:${PATH}"
 export PYTHONPATH="${EIB_SRCDIR}/lib${PYTHONPATH:+:$PYTHONPATH}"


### PR DESCRIPTION
Newer git prevents operations when the calling user is not the same as the user owning the repo. Currently the only git operation run is `git rev-parse HEAD` to record the builder commit in the manifest, but even that is enough to make git fail. Add the repo as a safe directory inside the build root since the builder is running as root and the repo may not be owned by root.

https://community.endlessos.com/t/custom-build-problem-with-5-0/19900