### PR TITLE
Backport "config: Set eos-runtimes remote to use new repo URL" to eos4.0

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -454,8 +454,8 @@ apps_add =
   com.endlessm.resume
 
 [flatpak-remote-eos-runtimes]
-url = ${ostree:prod_pull_repo_url}/eos
-deploy_url = ${ostree:prod_deploy_repo_url}/eos
+url = ${ostree:prod_pull_repo_url}/eos-runtimes
+deploy_url = ${ostree:prod_deploy_repo_url}/eos-runtimes
 
 [flatpak-remote-eos-sdk]
 url = ${ostree:prod_pull_repo_url}/eos-sdk


### PR DESCRIPTION
The legacy runtimes have been copied out of the eos repo to a new eos-runtimes repo so that it can be treated as a pure flatpak repo. This starts a long process where eventually we can remove the legacy runtimes from the eos repo and treat it as a pure ostree repo.

https://phabricator.endlessm.com/T33445
(cherry picked from commit ee650095568fde01e689b9ca4cf0f8c54c25b562)