### PR TITLE
config: Move gnome-font-viewer to flatpak

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -474,6 +474,7 @@ apps_add_mandatory =
   org.gnome.Cheese
   org.gnome.Rhythmbox3
   org.gnome.Totem
+  org.gnome.font-viewer
   org.libreoffice.LibreOffice
 apps_add =
   cc.arduino.arduinoide


### PR DESCRIPTION
(cherry picked from commit 3b2cde7d7aabb2d71eb0d979a49773ba7df75306)

https://phabricator.endlessm.com/T33982

This is a backport of #53. I'm not backporting the other two bits (automatically installing this Flatpak on upgrade https://github.com/endlessm/eos-application-tools/pull/71 https://github.com/endlessm/eos-application-tools/pull/73; and removing it from the base OS https://github.com/endlessm/eos-meta/pull/723) because this is an LTS and I want to minimize changes to the OS. But the built-in version of Fonts on eos4.0 is just pretty broken, so in the case where people are building new eos4.0 images, they should get the Flatpak version.