### PR TITLE
Kolibri remote import

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,6 @@ indent_style = space
 indent_size = 2
 
 # Python
-[{*.py,eos-image-builder,run-build,helpers/{assemble-manifest,fetch-remote-collection-id,generate-ovf-files,kill-chroot-procs,kolibri-pick-content-from-channel,mutable-path,packages-manifest},hooks/{content/50-flatpak,image/{50-flatpak.chroot,62-kolibri-options,70-flatpak-manifest,70-ostree-manifest}}}]
+[{*.py,eos-image-builder,run-build,helpers/{assemble-manifest,fetch-remote-collection-id,generate-ovf-files,kill-chroot-procs,kolibri-pick-content-from-channel,mutable-path,packages-manifest},hooks/{content/{50-flatpak,50-kolibri-content},image/{50-flatpak.chroot,62-kolibri-options,70-flatpak-manifest,70-ostree-manifest}}}]
 indent_size = 4
 max_line_length = 88

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,4 +15,5 @@ indent_size = 2
 
 # Python
 [{*.py,eos-image-builder,run-build,helpers/{assemble-manifest,fetch-remote-collection-id,generate-ovf-files,kill-chroot-procs,kolibri-pick-content-from-channel,mutable-path,packages-manifest},hooks/{content/50-flatpak,image/{50-flatpak.chroot,62-kolibri-options,70-flatpak-manifest,70-ostree-manifest}}}]
+indent_size = 4
 max_line_length = 88

--- a/.flake8
+++ b/.flake8
@@ -14,6 +14,7 @@ filename =
     ./helpers/mutable-path,
     ./helpers/packages-manifest,
     ./hooks/content/50-flatpak,
+    ./hooks/content/50-kolibri-content,
     ./hooks/image/50-flatpak.chroot,
     ./hooks/image/62-kolibri-options,
     ./hooks/image/70-flatpak-manifest,

--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ such as S3. See the
 [AWS documentation](http://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html)
 for details on this file.
 
+Netrc authentication
+--------------------
+
+Authentication credentials for various remote servers are stored in a
+netrc(5) file at `/etc/eos-image-builder/netrc`. This can be passed to
+`curl` or parsed with the `netrc` `python` module.
+
 Configuration
 =============
 

--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -117,6 +117,7 @@ aptcache_max_size = 2147483648
 hooks_add =
   50-flatpak
   50-gnome-software-cache
+  50-kolibri-content
 
 [image]
 # Merged customization hooks to run.
@@ -257,6 +258,10 @@ automatic_provision_allow_guest_access = false
 # By default, kolibri uses https://studio.learningequality.org as the
 # base content URL. This can be used to import channels from a custom
 # Kolibri server. If cleared, the upstream default will be used.
+#
+# If API credentials are provided in netrc authentication, the builder
+# will ask the server to import any channels listed in install_channels
+# below.
 central_content_base_url =
 
 regular_users_can_manage_content = false

--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -255,10 +255,8 @@ automatic_provision_learner_can_sign_up = false
 automatic_provision_allow_guest_access = false
 
 # By default, kolibri uses https://studio.learningequality.org as the
-# base content URL. Offload that to our own CDN during the image build.
-# If cleared, the upstream default will be used.
-# NOTE: we are temporarily pointing directy to Kolibri Studio while we fix
-# some issues with our CDN not being able to get some content.
+# base content URL. This can be used to import channels from a custom
+# Kolibri server. If cleared, the upstream default will be used.
 central_content_base_url =
 
 regular_users_can_manage_content = false

--- a/hooks/content/50-kolibri-content
+++ b/hooks/content/50-kolibri-content
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+
+# Instruct the Kolibri content server to import channels needed for this
+# build.
+
+import eib
+import logging
+from netrc import netrc
+import os
+import requests
+from urllib.parse import urljoin, urlparse
+
+logger = logging.getLogger(os.path.basename(__file__))
+
+
+def get_job_status(session, base_url, job_id):
+    url = urljoin(base_url, f'api/tasks/tasks/{job_id}/')
+    with session.get(url) as resp:
+        resp.raise_for_status()
+        return resp.json()
+
+
+def wait_for_job(session, base_url, job_id):
+    logger.debug(f'Waiting for job {job_id} to complete')
+    last_marker = None
+    while True:
+        data = get_job_status(session, base_url, job_id)
+
+        # See the kolibri.core.tasks.job.State class for potential states
+        # https://github.com/learningequality/kolibri/blob/develop/kolibri/core/tasks/job.py#L17
+        status = data['status']
+        if status == 'FAILED':
+            logger.error(
+              f'Job {job_id} failed: {data["exception"]}\n{data["traceback"]}'
+            )
+            raise Exception(f'Job {job_id} failed')
+        elif status == 'CANCELED':
+            raise Exception(f'Job {job_id} cancelled')
+        elif status == 'COMPLETED':
+            if last_marker < 100:
+                logger.info('Progress: 100%')
+            break
+
+        pct = int(data['percentage'] * 100)
+        marker = pct - pct % 5
+        if last_marker is None or marker > last_marker:
+            logger.info(f'Progress: {pct}%')
+            last_marker = marker
+
+
+def import_channel(session, base_url, channel_id):
+    url = urljoin(base_url, 'api/tasks/tasks/startremotechannelimport/')
+    data = {'channel_id': channel_id}
+    logger.info(f'Importing channel {channel_id} metadata')
+    with session.post(url, json=data) as resp:
+        try:
+            resp.raise_for_status()
+        except requests.exceptions.HTTPError:
+            logger.error('Failed to import channel: %s', resp.json())
+            raise
+        job = resp.json()
+
+    wait_for_job(session, base_url, job['id'])
+
+
+def import_content(session, base_url, channel_id, node_ids=None,
+                   exclude_node_ids=None):
+    url = urljoin(base_url, 'api/tasks/tasks/startremotecontentimport/')
+    data = {
+        'channel_id': channel_id,
+        'fail_on_error': True,
+        'timeout': 300,
+    }
+    if node_ids:
+        data['node_ids'] = node_ids
+    if exclude_node_ids:
+        data['exclude_node_ids'] = exclude_node_ids
+    logger.info(f'Importing channel {channel_id} content')
+    with session.post(url, json=data) as resp:
+        try:
+            resp.raise_for_status()
+        except requests.exceptions.HTTPError:
+            logger.error('Failed to import content: %s', resp.json())
+            raise
+        job = resp.json()
+
+    wait_for_job(session, base_url, job['id'])
+
+
+def main():
+    eib.setup_logging()
+    config = eib.get_config()
+
+    channels_var = config.get('kolibri', 'install_channels', fallback='')
+    if not channels_var.strip():
+        logger.info('No Kolibri channels to import')
+        return
+
+    base_url = config.get('kolibri', 'central_content_base_url', fallback=None)
+    if not base_url:
+        logger.info('Not using custom Kolibri content server')
+        return
+
+    netrc_path = os.path.join(eib.SYSCONFDIR, 'netrc')
+    if not os.path.exists(netrc_path):
+        logger.info(f'No credentials in {netrc_path}')
+        return
+
+    netrc_creds = netrc(netrc_path)
+    host = urlparse(base_url).netloc
+    creds = netrc_creds.authenticators(host)
+    if not creds:
+        logger.info(f'No credentials for {host}')
+        return
+    username, _, password = creds
+
+    # Build a dict of channel ID keys and option dict values.
+    channels = {}
+    for channel in channels_var.split():
+        channels[channel] = {}
+        options = f'kolibri-{channel}'
+        if config.has_section(options):
+            node_ids = config.get(options, 'include_node_ids', fallback='')
+            if node_ids:
+                channels[channel]['node_ids'] = node_ids.split()
+
+            exclude_node_ids = config.get(
+                options,
+                'exclude_node_ids',
+                fallback='',
+            )
+            if exclude_node_ids:
+                channels[channel]['exclude_node_ids'] = exclude_node_ids.split()
+
+    # Start a requests session with the credentials.
+    session = requests.Session()
+    session.auth = (username, password)
+    session.headers.update({
+        'Content-Type': 'application/json',
+    })
+
+    for channel, options in channels.items():
+        # Import the channel metadata.
+        import_channel(session, base_url, channel)
+
+        # Import the channel content.
+        import_content(
+            session,
+            base_url,
+            channel,
+            node_ids=options.get('node_ids'),
+            exclude_node_ids=options.get('exclude_node_ids'),
+        )
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
If a custom Kolibri content server is in use and credentials are
available, use the API to import the desired channels remotely. When the
time comes to populate the channels on the image, all the content will
be available on the server.

https://phabricator.endlessm.com/T33705