### PR TITLE
ostree: Don't verify summary on HTTPS

### DIFF
--- a/stages/eib_ostree
+++ b/stages/eib_ostree
@@ -21,11 +21,19 @@ else
 fi
 
 # Pull in the latest commit. Recreate the remote setup to ensure there
-# aren't any stale settings.
+# aren't any stale settings. Don't bother GPG verifying the summary if
+# it's being fetched over HTTPS. This often fails when the summary is
+# being updated concurrently since the received summary and summary
+# signature can be mismatched.
+if [[ ${BUILD_OSTREE_URL} =~ ^https:// ]]; then
+  gpg_verify_summary=false
+else
+  gpg_verify_summary=true
+fi
 ostree --repo="${EIB_OSTREE_REPODIR}" remote delete --if-exists \
   ${EIB_OSTREE_REMOTE}
 ostree --repo="${EIB_OSTREE_REPODIR}" remote add \
-  --set=gpg-verify-summary=true \
+  --set=gpg-verify-summary="${gpg_verify_summary}" \
   ${EIB_OSTREE_REMOTE} ${BUILD_OSTREE_URL} ${EIB_OSTREE_REF}
 eib_retry ostree --repo="${EIB_OSTREE_REPODIR}" pull \
   ${EIB_OSTREE_REMOTE} ${EIB_OSTREE_REF}


### PR DESCRIPTION
Don't bother GPG verifying the summary if it's being fetched over HTTPS. This often fails when the summary is being updated concurrently since the received summary and summary signature can be mismatched. The built image is already configured to not verify the summary.

https://phabricator.endlessm.com/T32658