### PR TITLE
gnome-software-cache: Update eos-extra cached appstream path

### DIFF
--- a/hooks/image/50-gnome-software-cache
+++ b/hooks/image/50-gnome-software-cache
@@ -1,18 +1,22 @@
 # Populate cache of gnome-software screenshots and thumbnails
 
-EXTRA_APPSTREAM_DIR=${OSTREE_VAR}/cache/app-info/xmls/
-EXTRA_APPSTREAM_FILE=org.gnome.Software-eos-extra.xml
+# Download and install the eos-extra AppStream catalog. Ideally we'd
+# just run gnome-software-cmd refresh, but at the moment that requires a
+# UI so the process is mimiced here.
+#
+# https://gitlab.gnome.org/GNOME/gnome-software/-/issues/2122
+EXTRA_APPSTREAM_DIR=${OSTREE_VAR}/cache/swcatalog/xml
+EXTRA_APPSTREAM_URL="https://appstream.endlessos.org/app-info/eos-extra.xml.gz"
+EXTRA_APPSTREAM_URL_HASH=$(echo -n "$EXTRA_APPSTREAM_URL" | sha1sum | awk '{print $1}')
+EXTRA_APPSTREAM_FILE="org.gnome.Software-${EXTRA_APPSTREAM_URL_HASH}-eos-extra.xml.gz"
+mkdir -p "${EXTRA_APPSTREAM_DIR}"
+wget -O "${EXTRA_APPSTREAM_DIR}/${EXTRA_APPSTREAM_FILE}" "${EXTRA_APPSTREAM_URL}"
 
+# Copy screenshots and thumbnails to deployment
 clone_dir=${EIB_CONTENTDIR}/gnome-software-data
 pushd $clone_dir
-  # Copy screenshots and thumbnails to deployment
   mkdir -p ${OSTREE_VAR}/cache/gnome-software/screenshots
   mkdir -p ${OSTREE_VAR}/cache/gnome-software/eos-popular-app-thumbnails
   cp -a screenshots/* ${OSTREE_VAR}/cache/gnome-software/screenshots
   cp -a thumbnails/* ${OSTREE_VAR}/cache/gnome-software/eos-popular-app-thumbnails
-
-  # Include the eos-extra AppStream file
-  mkdir -p ${EXTRA_APPSTREAM_DIR}
-  cp app-info/eos-extra.xml ${EXTRA_APPSTREAM_DIR}/${EXTRA_APPSTREAM_FILE}
-  gzip ${EXTRA_APPSTREAM_DIR}/${EXTRA_APPSTREAM_FILE}
 popd


### PR DESCRIPTION
2 changes are needed for the path:

* gnome-software now uses the non-legacy `/var/cache/swcatalog/xml` AppStream directory.
* gnome-software now includes a SHA1 hash of URL in the filename in case there are multiple external AppStream URLs with the same basename.

This also switches the XML to being downloaded rather than copied from the git repo. This validates the URL and ensures that the exact file is installed. This is what would happen if we later switch to using `gnome-software-cmd refresh`, anyways.

https://phabricator.endlessm.com/T34337