### PR TITLE
config: Add Epiphany to all images

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -480,6 +480,7 @@ apps_add_mandatory =
   org.gnome.Calculator
   org.gnome.Cheese
   org.gnome.Contacts
+  org.gnome.Epiphany
   org.gnome.FileRoller
   org.gnome.Logs
   org.gnome.Totem


### PR DESCRIPTION
Although Chromium remains the default browser, Epiphany is required for Progressive Web Application (PWA) support.

https://phabricator.endlessm.com/T34479
(cherry picked from commit d1fdae40fb48dbd04592e2b3445fcfa456876a20)
https://phabricator.endlessm.com/T34636