### PR TITLE
Create separate KOLIBRI_HOME for Endless Key

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -307,10 +307,6 @@ regular_users_can_manage_content = false
 # listed in this setting.
 install_channels =
 
-# By default we provision the Endless Key facility with the same settings from
-# the [kolibri] section.
-automatic_provision = true
-
 [usb]
 size = 16000000000
 free_space = 1000

--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -301,6 +301,16 @@ regular_users_can_manage_content = false
 #   # Kolibri 0.12.2 User Guide for Admins [document]
 #   5bb37c1832c8489ab2940f31588305f6
 
+[endlesskey]
+# Preloaded content or the Endless Key app
+# The Endless Key app can be pre-loaded with content from the Kolibri channels
+# listed in this setting.
+install_channels =
+
+# By default we provision the Endless Key facility with the same settings from
+# the [kolibri] section.
+automatic_provision = true
+
 [usb]
 size = 16000000000
 free_space = 1000

--- a/hooks/content/50-kolibri-content
+++ b/hooks/content/50-kolibri-content
@@ -91,9 +91,14 @@ def main():
     eib.setup_logging()
     config = eib.get_config()
 
-    channels_var = config.get('kolibri', 'install_channels', fallback='')
-    if not channels_var.strip():
+    kolibri_channels_var = config.get('kolibri', 'install_channels', fallback='')
+    if not kolibri_channels_var.strip():
         logger.info('No Kolibri channels to import')
+        return
+
+    ek_channels_var = config.get('endlesskey', 'install_channels', fallback='')
+    if not ek_channels_var.strip():
+        logger.info('No Endless Key channels to import')
         return
 
     base_url = config.get('kolibri', 'central_content_base_url', fallback=None)
@@ -116,21 +121,21 @@ def main():
 
     # Build a dict of channel ID keys and option dict values.
     channels = {}
-    for channel in channels_var.split():
+    for channel in ' '.join([kolibri_channels_var, ek_channels_var]).split():
         channels[channel] = {}
-        options = f'kolibri-{channel}'
-        if config.has_section(options):
-            node_ids = config.get(options, 'include_node_ids', fallback='')
-            if node_ids:
-                channels[channel]['node_ids'] = node_ids.split()
+        for options in [f'kolibri-{channel}', f'endlesskey-{channel}']:
+            if config.has_section(options):
+                node_ids = config.get(options, 'include_node_ids', fallback='')
+                if node_ids:
+                    channels[channel]['node_ids'] = node_ids.split()
 
-            exclude_node_ids = config.get(
-                options,
-                'exclude_node_ids',
-                fallback='',
-            )
-            if exclude_node_ids:
-                channels[channel]['exclude_node_ids'] = exclude_node_ids.split()
+                exclude_ids = config.get(
+                    options,
+                    'exclude_node_ids',
+                    fallback='',
+                )
+                if exclude_ids:
+                    channels[channel]['exclude_node_ids'] = exclude_ids.split()
 
     # Start a requests session with the credentials.
     session = requests.Session()

--- a/hooks/image/60-kolibri-content
+++ b/hooks/image/60-kolibri-content
@@ -1,6 +1,7 @@
 # Populate the Kolibri home directory
 
-if [ -z "${EIB_KOLIBRI_INSTALL_CHANNELS}" ]; then
+if [ -z "${EIB_KOLIBRI_INSTALL_CHANNELS}" ] &&
+   [ -z "${EIB_ENDLESSKEY_INSTALL_CHANNELS}" ]; then
   exit 0
 fi
 
@@ -15,9 +16,19 @@ export KOLIBRI_STATIC_USE_SYMLINKS=0
 
 import_kolibri_channel()
 {
-  local channel_id=$1
-  local channel_include_node_ids_var="EIB_KOLIBRI_${channel_id^^}_INCLUDE_NODE_IDS"
-  local channel_exclude_node_ids_var="EIB_KOLIBRI_${channel_id^^}_EXCLUDE_NODE_IDS"
+  local app_name=$1
+  local channel_id=$2
+
+  if [ ${app_name} == "kolibri" ]; then
+    local channel_include_node_ids_var="EIB_KOLIBRI_${channel_id^^}_INCLUDE_NODE_IDS"
+    local channel_exclude_node_ids_var="EIB_KOLIBRI_${channel_id^^}_EXCLUDE_NODE_IDS"
+  elif [ ${app_name} == "endless-key" ]; then
+    local channel_include_node_ids_var="EIB_ENDLESSKEY_${channel_id^^}_INCLUDE_NODE_IDS"
+    local channel_exclude_node_ids_var="EIB_ENDLESSKEY_${channel_id^^}_EXCLUDE_NODE_IDS"
+  else
+    exit 1
+  fi
+
   local importcontent_opts=(
     # Normally importcontent ignores download errors. Make it fail so we
     # can be sure we've fully provisioned channels.
@@ -45,42 +56,62 @@ import_kolibri_channel()
     network "${importcontent_network_opts[@]}" "${channel_id}"
 }
 
-# Needs to be kept in sync with hooks/image/61-kolibri-content-install
-KOLIBRI_CONTENT_DIR="${EIB_CONTENTDIR}/kolibri-content"
-# FIXME: For now, we need to remove old content that may exist from previous
-# runs to prevent images accidentally getting extra channels that are not in
-# their configuration. However, this defeats the purpose of the image builder
-# saving the contents of EIB_CONTENTDIR between runs to improve its performance.
-# At some point we should revisit this to try to make the caching work properly.
-rm -rf "${KOLIBRI_CONTENT_DIR}"
-mkdir -p "${KOLIBRI_CONTENT_DIR}"
+prepare_kolibri_env()
+{
+  local app_name=$1
+  # Needs to be kept in sync with hooks/image/61-kolibri-content-install
+  KOLIBRI_CONTENT_DIR="${EIB_CONTENTDIR}/${app_name}-content"
+  # FIXME: For now, we need to remove old content that may exist from previous
+  # runs to prevent images accidentally getting extra channels that are not in
+  # their configuration. However, this defeats the purpose of the image builder
+  # saving the contents of EIB_CONTENTDIR between runs to improve its performance.
+  # At some point we should revisit this to try to make the caching work properly.
+  rm -rf "${KOLIBRI_CONTENT_DIR}"
+  mkdir -p "${KOLIBRI_CONTENT_DIR}"
 
-venv_dir="${EIB_TMPDIR}/kolibri-content-venv"
-python3 -m venv ${venv_dir}
-source ${venv_dir}/bin/activate
+  venv_dir="${EIB_TMPDIR}/${app_name}-content-venv"
+  python3 -m venv ${venv_dir}
+  source ${venv_dir}/bin/activate
 
-pip install kolibri==${EIB_KOLIBRI_APP_VERSION}
-pip install kolibri-app-desktop-xdg-plugin==${EIB_KOLIBRI_APP_DESKTOP_XDG_PLUGIN_VERSION}
-pip install kolibri-desktop-auth-plugin==${EIB_KOLIBRI_DESKTOP_AUTH_PLUGIN_VERSION}
+  pip install kolibri==${EIB_KOLIBRI_APP_VERSION}
+  pip install kolibri-app-desktop-xdg-plugin==${EIB_KOLIBRI_APP_DESKTOP_XDG_PLUGIN_VERSION}
+  pip install kolibri-desktop-auth-plugin==${EIB_KOLIBRI_DESKTOP_AUTH_PLUGIN_VERSION}
 
-export KOLIBRI_HOME="${KOLIBRI_CONTENT_DIR}"
+  export KOLIBRI_HOME="${KOLIBRI_CONTENT_DIR}"
 
-kolibri plugin enable kolibri.plugins.app
-kolibri plugin enable kolibri_app_desktop_xdg_plugin
-kolibri plugin enable kolibri_desktop_auth_plugin
+  kolibri plugin enable kolibri.plugins.app
+  kolibri plugin enable kolibri_app_desktop_xdg_plugin
+  kolibri plugin enable kolibri_desktop_auth_plugin
 
-for channel_id in ${EIB_KOLIBRI_INSTALL_CHANNELS}; do
-  import_kolibri_channel "${channel_id}"
-done
+  if [ ${app_name} == "kolibri" ]; then
+    INSTALL_CHANNELS=("${EIB_KOLIBRI_INSTALL_CHANNELS[@]}")
+  elif [ ${app_name} == "endless-key" ]; then
+    INSTALL_CHANNELS=("${EIB_ENDLESSKEY_INSTALL_CHANNELS[@]}")
+  else
+    exit 1
+  fi
 
-# Sort channels in the same order as in EIB_KOLIBRI_INSTALL_CHANNELS
-position=1
-for channel_id in ${EIB_KOLIBRI_INSTALL_CHANNELS}; do
-  kolibri manage setchannelposition ${channel_id} ${position} || true
-  let position=position+1
-done
+  for channel_id in ${INSTALL_CHANNELS}; do
+    import_kolibri_channel "${app_name}" "${channel_id}"
+  done
 
-# Empty the user database, and ensure that each instance of this image has a
-# unique Facility ID.
-# <https://kolibri.readthedocs.io/en/latest/install/provision.html#prepare-the-kolibri-folder-for-copying>
-(echo yes; echo yes) | kolibri manage deprovision
+  # Sort channels in the same order as in INSTALL_CHANNELS
+  position=1
+  for channel_id in ${INSTALL_CHANNELS}; do
+    kolibri manage setchannelposition ${channel_id} ${position} || true
+    let position=position+1
+  done
+
+  # Empty the user database, and ensure that each instance of this image has a
+  # unique Facility ID.
+  # <https://kolibri.readthedocs.io/en/latest/install/provision.html#prepare-the-kolibri-folder-for-copying>
+  (echo yes; echo yes) | kolibri manage deprovision
+}
+
+if [ -n "${EIB_KOLIBRI_INSTALL_CHANNELS}" ]; then
+  prepare_kolibri_env "kolibri"
+fi
+
+if [ -n "${EIB_ENDLESSKEY_INSTALL_CHANNELS}" ]; then
+  prepare_kolibri_env "endless-key"
+fi

--- a/hooks/image/60-kolibri-content
+++ b/hooks/image/60-kolibri-content
@@ -14,6 +14,16 @@ fi
 # Do not create symlinks for static files inside the image builder.
 export KOLIBRI_STATIC_USE_SYMLINKS=0
 
+download_file() {
+  local url=${1:?No url supplied to ${FUNCNAME}}
+  local output=${2:?No output supplied to ${FUNCNAME}}
+  if [ -e "${output}" ]; then
+    curl -L --output "${output}" --time-cond "${output}" "${url}"
+  else
+    curl -L --output "${output}" "${url}"
+  fi
+}
+
 import_kolibri_channel()
 {
   local app_name=$1
@@ -143,4 +153,35 @@ fi
 
 if [ -n "${EIB_ENDLESSKEY_INSTALL_CHANNELS}" ]; then
   prepare_kolibri_env "endless-key"
+  apps_url=$(
+    curl -sSL https://api.github.com/repos/endlessm/kolibri-explore-plugin/releases/latest |
+    jq -r '.assets[] | select(.name == "apps-bundle.zip") | .browser_download_url'
+  )
+  collections_url=$(
+    curl -sSL https://api.github.com/repos/endlessm/endless-key-collections/releases/latest |
+    jq -r '.tarball_url'
+  )
+
+  PLUGIN_LOCATION=`pip3 show kolibri-explore-plugin | grep Location  | awk '{ print $2 }'`
+  APPS_LOCATION="${PLUGIN_LOCATION}/kolibri_explore_plugin"
+  COLLECTIONS_LOCATION="${PLUGIN_LOCATION}/kolibri_explore_plugin/static/collections/"
+
+  # Install apps bundle
+  download_file "${apps_url}" "${EIB_TMPDIR}/apps-bundle.zip"
+  unzip -o -d "${APPS_LOCATION}" "${EIB_TMPDIR}/apps-bundle.zip"
+  rm "${EIB_TMPDIR}/apps-bundle.zip"
+
+  # And install the collections metadata
+  download_file "${collections_url}" "${EIB_TMPDIR}/collections-bundle.tar.gz"
+  rm -f "${COLLECTIONS_LOCATION}/*.json"
+  mkdir -p "${COLLECTIONS_LOCATION}"
+  tar --extract \
+      --verbose \
+      --gzip \
+      --file "${EIB_TMPDIR}/collections-bundle.tar.gz" \
+      --directory="${COLLECTIONS_LOCATION}" \
+      --strip-components=2 \
+      --wildcards \
+      'endlessm-endless-key-collections-*/json/'
+  rm "${EIB_TMPDIR}/collections-bundle.tar.gz"
 fi

--- a/hooks/image/60-kolibri-content
+++ b/hooks/image/60-kolibri-content
@@ -74,14 +74,43 @@ prepare_kolibri_env()
   source ${venv_dir}/bin/activate
 
   pip install kolibri==${EIB_KOLIBRI_APP_VERSION}
-  pip install kolibri-app-desktop-xdg-plugin==${EIB_KOLIBRI_APP_DESKTOP_XDG_PLUGIN_VERSION}
-  pip install kolibri-desktop-auth-plugin==${EIB_KOLIBRI_DESKTOP_AUTH_PLUGIN_VERSION}
 
   export KOLIBRI_HOME="${KOLIBRI_CONTENT_DIR}"
 
-  kolibri plugin enable kolibri.plugins.app
-  kolibri plugin enable kolibri_app_desktop_xdg_plugin
-  kolibri plugin enable kolibri_desktop_auth_plugin
+  if [ ${app_name} == "kolibri" ]; then
+    PLUGINS_DISABLE=()
+    PLUGINS_ENABLE=(
+      "kolibri.plugins.app"
+      "kolibri_app_desktop_xdg_plugin"
+      "kolibri_desktop_auth_plugin"
+    )
+    pip install kolibri-app-desktop-xdg-plugin==${EIB_KOLIBRI_APP_DESKTOP_XDG_PLUGIN_VERSION}
+    pip install kolibri-desktop-auth-plugin==${EIB_KOLIBRI_DESKTOP_AUTH_PLUGIN_VERSION}
+  elif [ ${app_name} == "endless-key" ]; then
+    PLUGINS_DISABLE=(
+      "kolibri.plugins.default_theme"
+      "kolibri.plugins.learn"
+    )
+    PLUGINS_ENABLE=(
+      "kolibri.plugins.app"
+      "kolibri_endless_key_theme"
+      # FIXME: enabling kolibri-explore-plugin fails because we are using a
+      #        kolibri version that is too old.
+      #"kolibri_explore_plugin"
+      "kolibri_zim_plugin"
+    )
+    pip install kolibri_endless_key_theme
+    pip install kolibri_explore_plugin
+    pip install kolibri_zim_plugin
+  else
+    exit 1
+  fi
+  for plugin in "${PLUGINS_DISABLE[@]}"; do
+    kolibri plugin disable ${plugin}
+  done
+  for plugin in "${PLUGINS_ENABLE[@]}"; do
+    kolibri plugin enable ${plugin}
+  done
 
   if [ ${app_name} == "kolibri" ]; then
     INSTALL_CHANNELS=("${EIB_KOLIBRI_INSTALL_CHANNELS[@]}")

--- a/hooks/image/61-kolibri-content-install
+++ b/hooks/image/61-kolibri-content-install
@@ -1,12 +1,32 @@
 # Install the Kolibri home directory to the right location in the image
 
-if [ -z "${EIB_KOLIBRI_INSTALL_CHANNELS}" ]; then
+if [ -z "${EIB_KOLIBRI_INSTALL_CHANNELS}" ] &&
+   [ -z "${EIB_ENDLESSKEY_INSTALL_CHANNELS}" ]; then
   exit 0
 fi
 
-# Needs to be kept in sync with hooks/image/60-kolibri-content
-KOLIBRI_CONTENT_DIR="${EIB_CONTENTDIR}/kolibri-content"
+install_content()
+{
+  local app_name=$1
 
-mkdir -p "${OSTREE_VAR}"/lib/kolibri
+  if [ ${app_name} == "kolibri" ]; then
+    TARGET="${OSTREE_VAR}"/lib/kolibri
+  elif [ ${app_name} == "endless-key" ]; then
+    TARGET="${OSTREE_VAR}"/lib/endless-key
+  else
+    exit 1
+  fi
+  mkdir -p "${TARGET}"
 
-cp -rl "${KOLIBRI_CONTENT_DIR}" "${OSTREE_VAR}"/lib/kolibri/data
+  # Needs to be kept in sync with hooks/image/60-kolibri-content
+  KOLIBRI_CONTENT_DIR="${EIB_CONTENTDIR}/${app_name}-content"
+  cp -rl "${KOLIBRI_CONTENT_DIR}" "${TARGET}"/data
+}
+
+if [ -n "${EIB_KOLIBRI_INSTALL_CHANNELS}" ]; then
+  install_content "kolibri"
+fi
+
+if [ -n "${EIB_ENDLESSKEY_INSTALL_CHANNELS}" ]; then
+  install_content "endless-key"
+fi

--- a/hooks/image/62-kolibri-automatic-provision
+++ b/hooks/image/62-kolibri-automatic-provision
@@ -1,11 +1,12 @@
 # Configure Kolibri automatic provisioning if enabled
 
-if [ "${EIB_KOLIBRI_AUTOMATIC_PROVISION}" != "true" ] &&
-   [ "${EIB_ENDLESSKEY_AUTOMATIC_PROVISION}" != "true" ]; then
+if [ "${EIB_KOLIBRI_AUTOMATIC_PROVISION}" != "true" ]; then
   exit 0
 fi
 
-cat <<EOF > "${EIB_TMPDIR}"/automatic_provision.json
+mkdir -p "${OSTREE_VAR}"/lib/kolibri/data
+
+cat <<EOF > "${OSTREE_VAR}"/lib/kolibri/data/automatic_provision.json
 {
   "facility_name": "${EIB_KOLIBRI_AUTOMATIC_PROVISION_FACILITY_NAME}",
   "superuser": {
@@ -26,13 +27,3 @@ cat <<EOF > "${EIB_TMPDIR}"/automatic_provision.json
   }
 }
 EOF
-
-if [ "${EIB_KOLIBRI_AUTOMATIC_PROVISION}" == "true" ]; then
-  mkdir -p "${OSTREE_VAR}"/lib/kolibri/data
-  cp "${EIB_TMPDIR}"/automatic_provision.json "${OSTREE_VAR}"/lib/kolibri/data
-fi
-
-if [ "${EIB_ENDLESSKEY_AUTOMATIC_PROVISION}" == "true" ]; then
-  mkdir -p "${OSTREE_VAR}"/lib/endless-key/data
-  cp "${EIB_TMPDIR}"/automatic_provision.json "${OSTREE_VAR}"/lib/endless-key/data
-fi

--- a/hooks/image/62-kolibri-automatic-provision
+++ b/hooks/image/62-kolibri-automatic-provision
@@ -1,12 +1,11 @@
 # Configure Kolibri automatic provisioning if enabled
 
-if [ "${EIB_KOLIBRI_AUTOMATIC_PROVISION}" != "true" ]; then
+if [ "${EIB_KOLIBRI_AUTOMATIC_PROVISION}" != "true" ] &&
+   [ "${EIB_ENDLESSKEY_AUTOMATIC_PROVISION}" != "true" ]; then
   exit 0
 fi
 
-mkdir -p "${OSTREE_VAR}"/lib/kolibri/data
-
-cat <<EOF > "${OSTREE_VAR}"/lib/kolibri/data/automatic_provision.json
+cat <<EOF > "${EIB_TMPDIR}"/automatic_provision.json
 {
   "facility_name": "${EIB_KOLIBRI_AUTOMATIC_PROVISION_FACILITY_NAME}",
   "superuser": {
@@ -27,3 +26,13 @@ cat <<EOF > "${OSTREE_VAR}"/lib/kolibri/data/automatic_provision.json
   }
 }
 EOF
+
+if [ "${EIB_KOLIBRI_AUTOMATIC_PROVISION}" == "true" ]; then
+  mkdir -p "${OSTREE_VAR}"/lib/kolibri/data
+  cp "${EIB_TMPDIR}"/automatic_provision.json "${OSTREE_VAR}"/lib/kolibri/data
+fi
+
+if [ "${EIB_ENDLESSKEY_AUTOMATIC_PROVISION}" == "true" ]; then
+  mkdir -p "${OSTREE_VAR}"/lib/endless-key/data
+  cp "${EIB_TMPDIR}"/automatic_provision.json "${OSTREE_VAR}"/lib/endless-key/data
+fi

--- a/hooks/image/62-kolibri-options
+++ b/hooks/image/62-kolibri-options
@@ -5,11 +5,8 @@
 import configparser
 import functools
 import os
+import shutil
 from pathlib import Path
-
-OSTREE_VAR = Path(os.environ.get("OSTREE_VAR"))
-KOLIBRI_HOME = Path(OSTREE_VAR, "lib/kolibri/data")
-OPTIONS_FILE_PATH = Path(KOLIBRI_HOME, "options.ini")
 
 EIB_KOLIBRI_REGULAR_USERS_CAN_MANAGE_CONTENT = os.environ.get(
     "EIB_KOLIBRI_REGULAR_USERS_CAN_MANAGE_CONTENT"
@@ -32,6 +29,18 @@ config_count = functools.reduce(
     lambda total, section: total + len(section), config.values(), 0
 )
 
+EIB_TMPDIR = Path(os.environ.get("EIB_TMPDIR"))
+TMP_OPTIONS_FILE_PATH = Path(EIB_TMPDIR, "options.ini")
 if config_count > 0:
-    with open(OPTIONS_FILE_PATH, "w") as options_file:
+    with open(TMP_OPTIONS_FILE_PATH, "w") as options_file:
         config.write(options_file)
+
+    if "EIB_KOLIBRI_INSTALL_CHANNELS" in os.environ:
+        OSTREE_VAR = Path(os.environ.get("OSTREE_VAR"))
+        KOLIBRI_HOME = Path(OSTREE_VAR, "lib/kolibri/data")
+        shutil.copy(TMP_OPTIONS_FILE_PATH, KOLIBRI_HOME)
+
+    if "EIB_ENDLESSKEY_INSTALL_CHANNELS" in os.environ:
+        OSTREE_VAR = Path(os.environ.get("OSTREE_VAR"))
+        KOLIBRI_HOME = Path(OSTREE_VAR, "lib/endless-key/data")
+        shutil.copy(TMP_OPTIONS_FILE_PATH, KOLIBRI_HOME)


### PR DESCRIPTION
We want to be able to ship different content and configuration for
Kolibri and the Endless Key app. This commit adds support for installing
the content and configuration for each app to separate locations, so
they can be used side-by-side.

https://github.com/endlessm/eos-image-builder/issues/117
