### PR TITLE
config: Install Endless Key by default

### DIFF
--- a/config/branch-personality/master-base.ini
+++ b/config/branch-personality/master-base.ini
@@ -1,9 +1,0 @@
-# Settings for base personality with master branch
-
-[flatpak-remote-flathub]
-apps_del =
-  org.learningequality.Kolibri
-
-[flatpak-remote-flathub-beta]
-apps_add =
-  org.learningequality.Kolibri

--- a/config/branch/master.ini
+++ b/config/branch/master.ini
@@ -7,13 +7,6 @@ deploy_url = ${dev_deploy_repo_url}/${repo}
 # Master images should always follow the master ostree.
 stable_branch = ${build:branch}
 
-[flatpak-remote-flathub]
-# Don't install the stable version of Kolibri
-apps_del =
-  org.learningequality.Kolibri
-
+# Enable the Flathub beta repo.
 [flatpak-remote-flathub-beta]
-# Instead, install the beta version of Kolibri
 enable = true
-apps_add =
-  org.learningequality.Kolibri

--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -523,6 +523,7 @@ apps_add =
   io.thp.numptyphysics
   org.audacityteam.Audacity
   org.blender.Blender
+  org.endlessos.Key
   org.gimp.GIMP
   org.gnome.Gnote
   org.gnome.Rhythmbox3

--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -531,7 +531,6 @@ apps_add =
   org.inkscape.Inkscape
   org.kde.gcompris
   org.laptop.TurtleArtActivity
-  org.learningequality.Kolibri
   org.pitivi.Pitivi
   org.tuxpaint.Tuxpaint
 

--- a/config/personality/base.ini
+++ b/config/personality/base.ini
@@ -13,4 +13,5 @@ apps_del = ${apps_add_defaults}
 # Delete all default additions and explicitly build the list from scratch.
 apps_del = ${apps_add_defaults}
 apps_add =
+  org.endlessos.Key
   org.learningequality.Kolibri

--- a/config/personality/base.ini
+++ b/config/personality/base.ini
@@ -14,4 +14,3 @@ apps_del = ${apps_add_defaults}
 apps_del = ${apps_add_defaults}
 apps_add =
   org.endlessos.Key
-  org.learningequality.Kolibri


### PR DESCRIPTION
I think we want this installed by default for basically all images, although images that want preloaded content should also explicitly add it. For now I left org.learningequality.Kolibri preinstalled.