### PR TITLE
Fetch all Kolibri content nodes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,6 @@ indent_style = space
 indent_size = 2
 
 # Python
-[{*.py,eos-image-builder,run-build,helpers/{assemble-manifest,fetch-remote-collection-id,generate-ovf-files,kill-chroot-procs,kolibri-pick-content-from-channel,mutable-path,packages-manifest},hooks/{content/{50-flatpak,50-kolibri-content},image/{50-flatpak.chroot,62-kolibri-options,70-flatpak-manifest,70-ostree-manifest}}}]
+[{*.py,eos-image-builder,run-build,helpers/{assemble-manifest,fetch-remote-collection-id,generate-ovf-files,kill-chroot-procs,kolibri-pick-content-from-channel,mutable-path,packages-manifest},hooks/{content/{50-flatpak,50-kolibri-content},image/{50-flatpak.chroot,52-ek-content-cache,62-kolibri-options,70-flatpak-manifest,70-ostree-manifest}}}]
 indent_size = 4
 max_line_length = 88

--- a/hooks/content/50-kolibri-content
+++ b/hooks/content/50-kolibri-content
@@ -68,6 +68,8 @@ def import_content(session, base_url, channel_id, node_ids=None,
     url = urljoin(base_url, 'api/tasks/tasks/startremotecontentimport/')
     data = {
         'channel_id': channel_id,
+        # Fetch all nodes so that the channel is fully mirrored.
+        'renderable_only': False,
         'fail_on_error': True,
         'timeout': 300,
     }

--- a/hooks/image/52-ek-content-cache
+++ b/hooks/image/52-ek-content-cache
@@ -66,6 +66,8 @@ def import_content(session, base_url, channel_id):
     url = urljoin(base_url, 'api/tasks/tasks/startremotecontentimport/')
     data = {
         'channel_id': channel_id,
+        # Fetch all nodes so that the channel is fully mirrored.
+        'renderable_only': False,
         'fail_on_error': True,
         'timeout': 300,
     }

--- a/hooks/image/53-ek-content-preload
+++ b/hooks/image/53-ek-content-preload
@@ -29,7 +29,9 @@ channels=$(sort -u "${EIB_TMPDIR}"/ek-channels)
 for channel in $channels; do
   kolibri manage --skip-update importchannel network "${channel}"
   EIB_RETRY_ATTEMPTS=2 EIB_RETRY_INTERVAL=30 eib_retry \
-    kolibri manage --skip-update importcontent --fail-on-error network "${channel}"
+    kolibri manage --skip-update \
+    importcontent --include-unrenderable-content --fail-on-error \
+    network "${channel}"
 done
 
 # Empty the user database, and ensure that each instance of this image has a

--- a/hooks/image/60-kolibri-content
+++ b/hooks/image/60-kolibri-content
@@ -10,6 +10,11 @@ import_kolibri_channel()
   local channel_include_node_ids_var="EIB_KOLIBRI_${channel_id^^}_INCLUDE_NODE_IDS"
   local channel_exclude_node_ids_var="EIB_KOLIBRI_${channel_id^^}_EXCLUDE_NODE_IDS"
   local importcontent_opts=(
+    # By default, importcontent skips content nodes that it doesn't
+    # think are renderable. Since we don't know what renderers will be
+    # available at runtime, request everything.
+    --include-unrenderable-content
+
     # Normally importcontent ignores download errors. Make it fail so we
     # can be sure we've fully provisioned channels.
     --fail-on-error


### PR DESCRIPTION
Kolibri defaults to only downloading content nodes that it believes the current instance can render. Both the image builder and the content server have Kolibri instances that don't necessarily have all available content renderers. To be safe they should download content nodes without regard for whether Kolibri thinks they're renderable. For the `importcontent` CLI, that's the `--include-unrenderable-content` option. For the task API, that's the `renderable_only` option.

Helps: https://github.com/endlessm/endless-key-content-private/issues/103