### PR TITLE
Drop nexthw platform config

### DIFF
--- a/config/platform/nexthw.ini
+++ b/config/platform/nexthw.ini
@@ -1,5 +1,0 @@
-[ostree]
-# For nexthw, instead of using a wide "eos3" ref, we use the same ref as
-# the one used for the build, and later use a commit-metadata redirect to
-# bring the users onto the mainline platform
-ref_deploy = ${ref}

--- a/tests/test_image_builder.py
+++ b/tests/test_image_builder.py
@@ -68,9 +68,11 @@ def test_series(make_builder, branch, expected):
 
 
 @pytest.mark.parametrize('arch,platform,expected', [
-    ('amd64', 'nexthw', 'nexthw'), ('amd64', None, 'amd64'),
-    ('arm64', 'rpi4', 'rpi4'), ('arm64', None, 'arm64'),
-    ('i386', 'i386', 'i386'), ('i386', None, 'i386'),
+    ('amd64', None, 'amd64'),
+    ('arm64', 'rpi4', 'rpi4'),
+    ('arm64', None, 'arm64'),
+    ('i386', 'i386', 'i386'),
+    ('i386', None, 'i386'),
 ])
 def test_platform(make_builder, arch, platform, expected):
     builder = make_builder(arch=arch, platform=platform)


### PR DESCRIPTION
The nexthw build is dropped since EOS 5.1.

https://phabricator.endlessm.com/T35027