### PR TITLE
config: Add ar.com.pilas_engine.App to es images

### DIFF
--- a/config/personality/es.ini
+++ b/config/personality/es.ini
@@ -39,3 +39,7 @@ apps_add =
   com.endlessm.travel.es
   com.endlessm.water_and_sanitation.es
   com.endlessm.world_literature.es
+
+[flatpak-remote-flathub]
+apps_add =
+  ar.com.pilas_engine.App


### PR DESCRIPTION
This game making application is currently only useful in Spanish, so we will add it to the "es" personality.

https://phabricator.endlessm.com/T34960