### PR TITLE
Stop installing Hack apps by default

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -480,9 +480,6 @@ apps_add_mandatory =
 [flatpak-remote-flathub]
 repo_file = https://dl.flathub.org/repo/flathub.flatpakrepo
 apps_add_mandatory =
-  com.hack_computer.Clubhouse
-  com.hack_computer.OperatingSystemApp
-  com.hack_computer.Sidetrack
   org.chromium.Chromium
   org.gnome.Calculator
   org.gnome.Cheese


### PR DESCRIPTION
We are no longer maintaining Hack. The apps will remain available on Flathub (unless/until they are EOLed) and installed on existing systems.

https://phabricator.endlessm.com/T35054