### PR TITLE
buildroot: Replace exfat-utils with exfatprogs for bookworm

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -67,7 +67,7 @@ packages_add =
   eos-keyring
   eos-tech-support
   exfat-fuse
-  exfat-utils
+  exfatprogs
   fdisk
   flatpak
   gir1.2-flatpak-1.0


### PR DESCRIPTION
Now that the OS is based on bookworm, exfat-utils is no longer available and exfatprogs needs to be installed. Neither package is used directly by the image builder but rather by `eos-write-live-image`. Unfortunately, the `eos-tech-support` package it comes from does not declare the needed dependency.

https://phabricator.endlessm.com/T35035