### PR TITLE
Handle missing Flatpaks gracefully

### DIFF
--- a/lib/eibflatpak.py
+++ b/lib/eibflatpak.py
@@ -794,14 +794,17 @@ class FlatpakManager(object):
 
     def _add_installs(self, transaction):
         for remote in self.remotes.values():
-            for app in remote.apps:
-                ref = remote.match(app, Flatpak.RefKind.APP)
-                logger.info('Adding app %s from %s', ref.ref, remote.name)
-                transaction.add_install(remote.name, ref.ref, None)
-            for runtime in remote.runtimes:
-                ref = remote.match(runtime, Flatpak.RefKind.RUNTIME)
-                logger.info('Adding runtime %s from %s', ref.ref, remote.name)
-                transaction.add_install(remote.name, ref.ref, None)
+            for kind, ref_strs in (
+                (Flatpak.RefKind.APP, remote.apps),
+                (Flatpak.RefKind.RUNTIME, remote.runtimes),
+            ):
+                kind_str = kind.value_nick
+                for ref_str in ref_strs:
+                    ref = remote.match(ref_str, kind)
+                    logger.info(
+                        'Adding %s %s from %s', kind_str, ref.ref, remote.name
+                    )
+                    transaction.add_install(remote.name, ref.ref, None)
 
     def _new_transaction(self):
         txn = Flatpak.Transaction.new_for_installation(self.installation)


### PR DESCRIPTION
Previously, if a listed Flatpak app or runtime is not present in that
remote, remote.match() would return None, but the calling code would
assume it is not None. This leads to a failure like this:

    + 20:16:29 INFO eibflatpak: Looking for app ref "com.orama_interactive.Pixelorama" match in flathub
    + 20:16:29 INFO eibflatpak: Removing repo option core.xa.languages
    + 20:16:29 INFO eibflatpak: Removing repo option core.xa.extra-languages
    + 20:16:29 INFO eibflatpak: Removing repo option core.xa.masked
    Traceback (most recent call last):
      File "/tmp/image-build-IZAJlTeyep/eos-image-builder/hooks/content/50-flatpak", line 61, in <module>
        manager.pull()
      File "/tmp/image-build-IZAJlTeyep/eos-image-builder/lib/eibflatpak.py", line 837, in pull
        txn = self._new_transaction()
      File "/tmp/image-build-IZAJlTeyep/eos-image-builder/lib/eibflatpak.py", line 808, in _new_transaction
        self._add_installs(txn)
      File "/tmp/image-build-IZAJlTeyep/eos-image-builder/lib/eibflatpak.py", line 799, in _add_installs
        logger.info('Adding app %s from %s', ref.ref, remote.name)
    AttributeError: 'NoneType' object has no attribute 'ref'

Handle this gracefully, collecting all errors in case more than one
Flatpak is missing, then fail at the end.

https://phabricator.endlessm.com/T34603
