### PR TITLE
Update gnome-initial-setup vendor configuration path

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -222,7 +222,7 @@ branding_desktop_config =
 branding_desktop_logo =
 
 # Brand-specific configuration for the First Boot Experience
-branding_fbe_config = ${build:datadir}/branding/gnome-initial-setup/default/gnome-initial-setup.conf
+branding_fbe_config = 
 
 # Environment variables to substitute in branding configuration files
 branding_subst_vars_add =

--- a/data/branding/gnome-initial-setup/default/gnome-initial-setup.conf
+++ b/data/branding/gnome-initial-setup/default/gnome-initial-setup.conf
@@ -1,5 +1,0 @@
-[pages]
-run_welcome_tour=false
-
-[Language]
-initial_languages=en_US.UTF-8;pt_BR.UTF-8;es_MX.UTF-8;id_ID.UTF-8;fr_FR.UTF-8;ar_AE.UTF-8;ru_RU.UTF_8;ro_RO.UTF-8

--- a/hooks/image/50-branding-fbe
+++ b/hooks/image/50-branding-fbe
@@ -18,9 +18,3 @@ CONFIG_DIR="${OSTREE_VAR}"/lib/eos-image-defaults/branding
 
 mkdir -p "${CONFIG_DIR}"
 cp "${EIB_IMAGE_BRANDING_FBE_CONFIG}" "${CONFIG_DIR}"/
-
-CONFIG_BASENAME=$(basename "${EIB_IMAGE_BRANDING_FBE_CONFIG}")
-
-for SUBST_VAR in ${EIB_IMAGE_BRANDING_SUBST_VARS}; do
-    sed -i "s|@${SUBST_VAR}@|${!SUBST_VAR}|g" "${CONFIG_DIR}"/"${CONFIG_BASENAME}"
-done

--- a/hooks/image/50-branding-fbe
+++ b/hooks/image/50-branding-fbe
@@ -24,8 +24,3 @@ CONFIG_BASENAME=$(basename "${EIB_IMAGE_BRANDING_FBE_CONFIG}")
 for SUBST_VAR in ${EIB_IMAGE_BRANDING_SUBST_VARS}; do
     sed -i "s|@${SUBST_VAR}@|${!SUBST_VAR}|g" "${CONFIG_DIR}"/"${CONFIG_BASENAME}"
 done
-
-# The skipped pages file and the logo are optional
-if [ -n "${EIB_IMAGE_BRANDING_FBE_SKIP_PAGES_FILE}" ]; then
-    cp "${EIB_IMAGE_BRANDING_FBE_SKIP_PAGES_FILE}" "${CONFIG_DIR}"/
-fi

--- a/hooks/image/50-branding-fbe
+++ b/hooks/image/50-branding-fbe
@@ -1,7 +1,6 @@
-# Adds the configuration file and assets to customize the welcome page of the FBE.
+# Adds a configuration file to customise GNOME Initial Setup.
 #
-# The file will live in /var/lib/eos-image-defaults/branding/gnome-initial-setup.conf,
-# and any related resources (e.g. logo) under /var/lib/eos-image-defaults/branding/assets.
+# The file will live in /etc/gnome-initial-setup/vendor.conf.
 
 if [ -z "${EIB_IMAGE_BRANDING_FBE_CONFIG}" ]; then
     exit 0
@@ -14,7 +13,7 @@ if [ "$CHECK" != OK ]; then
     exit 1
 fi
 
-CONFIG_DIR="${OSTREE_VAR}"/lib/eos-image-defaults/branding
+CONFIG_PATH="${OSTREE_DEPLOYMENT}"/etc/gnome-initial-setup/vendor.conf
 
-mkdir -p "${CONFIG_DIR}"
-cp "${EIB_IMAGE_BRANDING_FBE_CONFIG}" "${CONFIG_DIR}"/
+mkdir -p "$(dirname "$CONFIG_PATH")"
+cp "${EIB_IMAGE_BRANDING_FBE_CONFIG}" "$CONFIG_PATH"


### PR DESCRIPTION
Previously we built GNOME Initial Setup to use the path
/var/lib/eos-image-defaults/branding/gnome-initial-setup.conf and
installed the keyfile specified in the '[image] branding_fbe_config' key
there. (There was no validation that its name was actually
gnome-initial-setup.conf, which was necessary for it to work.)

When we contributed this feature upstream to gnome-initial-setup, the
path was made configurable with a build-time parameter, with no default.

Some time later, Initial Setup started reading
/etc/gnome-initial-setup/vendor.conf if present; and
/usr/share/gnome-initial-setup/vendor.conf otherwise. It retained a
build-time parameter, which we continued to set; but setting that
parameter disabled *both* of the upstream paths.

With the upstream behaviour, it is possible to ship overrides in the
immutable bit of the OS, and further override them in /etc. This is in
my opinion preferable to what we have historically done, to
always write a file in /var for all images, even if the specific image
does not want any image-specific customisation of Initial Setup.

Install any config file to the upstream path in /etc, matching a build
configuration change I will make in our gnome-initial-setup package.

Remove default gnome-initial-setup vendor.conf in favour of https://github.com/endlessm/eos-theme/pull/392.

https://phabricator.endlessm.com/T35040
