### PR TITLE
config: Install python3-dev package in buildroot

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -84,6 +84,7 @@ packages_add =
   pigz
   python3
   python3-apt
+  python3-dev
   python3-gi
   python3-requests
   python3-venv


### PR DESCRIPTION
If the build needs to install a Python package from PyPI (like hooks/image/60-kolibri-content), it's possible that it will need to be built natively from source if there are no binary wheels available for the current Python version. That fails if the Python development environment isn't available.

https://phabricator.endlessm.com/T35125