### PR TITLE
eibkolibri: Follow channel update with channel import

### DIFF
--- a/lib/eibkolibri.py
+++ b/lib/eibkolibri.py
@@ -190,12 +190,13 @@ class RemoteKolibri:
         """Import or update channel and content on remote Kolibri server
 
         If the channel exists, it will be updated since Kolibri won't
-        import new content nodes otherwise.
+        import new content nodes otherwise. An import is always run to
+        ensure any nodes missed because of a previous failure are
+        imported.
         """
         if self._channel_exists(channel_id):
             self.update_channel(channel_id)
-        else:
-            self.import_channel(channel_id)
+        self.import_channel(channel_id)
 
     def _get_server_series(self):
         """Determine the server Kolibri series"""


### PR DESCRIPTION
If new nodes are added in a new channel version, the channel needs to be updated or they will be skipped if they're below an already existing node. However, if there are missing nodes from a previously failed import, then a regular import is needed. Therefore, follow a channel update with a channel import.

The update is run first because the algorithm for calculating newly needed nodes depends on comparing the old and new versions of the channel metadata. One a regular import is done, the old version of the channel metadata is replaced and the calculation can't be made anymore.

https://phabricator.endlessm.com/T34697