### PR TITLE
kolibri: Update kolibri-app-desktop-xdg-plugin to 1.2.0

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -225,7 +225,7 @@ branding_subst_vars_add =
 
 [kolibri]
 app_version = 0.15.12
-app_desktop_xdg_plugin_version = 1.1.4
+app_desktop_xdg_plugin_version = 1.2.0
 desktop_auth_plugin_version = 0.0.7
 
 automatic_provision = false


### PR DESCRIPTION
This has been updated in the org.learningequality.Kolibri flatpak. Most importantly, its Pillow dependency has been updated to a version that has binary wheels for Python 3.11.

https://phabricator.endlessm.com/T35125