### PR TITLE
create-iso: Use non-branched endless-installer.exe

### DIFF
--- a/helpers/create-iso
+++ b/helpers/create-iso
@@ -48,11 +48,9 @@ create_iso() {
   # builder is unaware of localised personality names
   label="${EIB_IMAGE_PRODUCT_NAME} ${version} ${personality}"
 
-  # Download from a non-standard URL to allow us to QA the installer for
-  # the branch we're building, ahead of the main release.
   # TODO: Perhaps we should create a package in OBS which just contains
   # endless-installer.exe?
-  local ei_url="https://images-dl.endlessm.com/endless-installer/endless-installer-${EIB_BRANCH}.exe"
+  local ei_url="https://images-dl.endlessm.com/endless-installer/endless-installer.exe"
   local ei_exe="${DIR_IMAGES}/endless-installer.exe"
   wget -O "${ei_exe}" "${ei_url}"
 


### PR DESCRIPTION
In effect, this reverts 4a167ae3bd3dd67785d21cc3a1cbacc4fefcee36 and
a2f1eb46ae0008283b926f56cab8d7f6a4ec02e8.

In the past, the Endless Installer for Windows was under active
development, with corresponding changes in the OS. To be able to e.g.
test the installer from within an ISO built by our infrastructure before
releasing the installer changes to the public, we had to fetch the
installer from a branched URL.

Now the installer is essentially dead, this just adds extra steps to our
release process for no benefit. Fetch from an unbranched URL.

I stand by the TODO I wrote in 977b96d8b0ae44c431b8596ddf4871e5377f311e
though it seems vanishingly unlikely we will ever do that.

https://phabricator.endlessm.com/T35105
