### PR TITLE
Revert "config: Add spanish-extras collection to the es personality"

### DIFF
--- a/config/personality/en.ini
+++ b/config/personality/en.ini
@@ -35,4 +35,3 @@ collections =
   extras
   inventor
   scientist
-  spanish-extras


### PR DESCRIPTION
This reverts commit 2233b93d25fe40893b50a25e14d9c04dcc8d1fda.

Instead, the Spanish content we want to be available is being added in endlessm/endless-key-collections#39.

https://phabricator.endlessm.com/T35170