### PR TITLE
Remove Cheese from mandatory apps

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -475,7 +475,6 @@ repo_file = https://dl.flathub.org/repo/flathub.flatpakrepo
 apps_add_mandatory =
   org.chromium.Chromium
   org.gnome.Calculator
-  org.gnome.Cheese
   org.gnome.Contacts
   org.gnome.Epiphany
   org.gnome.FileRoller
@@ -508,6 +507,7 @@ apps_add =
   org.blender.Blender
   org.endlessos.Key
   org.gimp.GIMP
+  org.gnome.Cheese
   org.gnome.Gnote
   org.gnome.Rhythmbox3
   org.gnome.Weather


### PR DESCRIPTION
Cheese was moved from the OS to a Flatpak in eos4.0. There has been a checkpoint between eos4.0 and eos5.0+, so we can now remove the flatpak-autoinstall.d rule that requires it to be installed. It follows that we can relegate it to "default" status, which in particular means that base images need no longer include it.

Depends on:

- [ ] https://github.com/endlessm/eos-application-tools/pull/83

https://phabricator.endlessm.com/T35175