### PR TITLE
Stop preinstalling GNOME Logs

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -478,7 +478,6 @@ apps_add_mandatory =
   org.gnome.Contacts
   org.gnome.Epiphany
   org.gnome.FileRoller
-  org.gnome.Logs
   org.gnome.Totem
   org.gnome.Shotwell
   org.gnome.font-viewer


### PR DESCRIPTION
In eos4.0 (and earlier), gnome-logs was baked into the OSTree. It is in apps_add_mandatory because we used flatpak-autoinstall.d to cause the Flatpak version to be installed when upgrading from eos4.0 to eos5.[01] so that the app does not disappear with the upgrade.

However this is really quite a niche app, so we will just stop doing that. Our metrics show that this app is very seldom used. People who need to read the journal, and prefer this app to journalctl, can install it from the App Center.

Depends on:

- [x] https://github.com/endlessm/eos-application-tools/pull/84

https://phabricator.endlessm.com/T35176