### PR TITLE
Revert "arm64: Exclude GDevelop"

### DIFF
--- a/config/arch/arm64.ini
+++ b/config/arch/arm64.ini
@@ -30,6 +30,5 @@ apps_del =
   com.orama_interactive.Pixelorama
   edu.mit.Scratch
   io.atom.Atom
-  io.gdevelop.ide
   io.lmms.LMMS
   org.blender.Blender


### PR DESCRIPTION
This reverts commit 4b2d57a37d14ef927ccda9e1c2179231b02f0430.

https://github.com/flathub/io.gdevelop.ide/pull/30 was accepted: GDevelop should be available for arm64 in the coming hours!