### PR TITLE
Exclude org.freedesktop.Platform.ffmpeg_full.i386 extension

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -535,6 +535,7 @@ exclude_add =
   org.blender.Blender.Codecs
   org.freedesktop.Platform.ffmpeg
   org.freedesktop.Platform.ffmpeg-full
+  org.freedesktop.Platform.ffmpeg_full.i386
   org.freedesktop.Platform.html5-codecs
   org.gnome.Totem.Codecs
   org.kde.kdenlive


### PR DESCRIPTION
I learned today that, in addition to the
runtime/org.freedesktop.Platform.ffmpeg-full/$ARCH/23.08 extension that exists on
all architectures, on x86_64 there is also
runtime/org.freedesktop.Platform.ffmpeg_full.i386/x86_64/23.08 to
support 32-bit binaries in an otherwise 64-bit environment. This runtime
was not being explicitly excluded from our images.

I checked the image server database with the following query:

    select
        build_id
    from
        builds_manifest
    where
        (data -> 'flatpak' -> 'runtimes') ?| array[
            'org.freedesktop.Platform.ffmpeg_full.i386/x86_64/20.08',
            'org.freedesktop.Platform.ffmpeg_full.i386/x86_64/21.08',
            'org.freedesktop.Platform.ffmpeg_full.i386/x86_64/22.08',
            'org.freedesktop.Platform.ffmpeg_full.i386/x86_64/23.08'
        ]
    limit 1;

(`object ?| keys` is true if the JSON value `object` contains any
element of the array `keys` as a key.
https://www.postgresql.org/docs/13/functions-json.html)

Happily, we have never accidentally shipped this extension. Exclude it
just to be safe.
