### PR TITLE
defaults: Don't explicitly add openh264 or Chromium.Codecs

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -515,8 +515,6 @@ apps_add =
 # Convenience variable primarily for other configurations to add or
 # delete runtimes from the default set
 runtimes_add =
-  org.chromium.Chromium.Codecs
-  org.freedesktop.Platform.openh264
 
 # List of IDs (apps, runtimes or extensions) to never install
 exclude_add =


### PR DESCRIPTION
This partially reverts afc6ff82c814903eaa8ac22e524e7ea334b16146
(“config: Include H.264 and MPEG4 by default”).

It is not necessary to explicitly install these:

- If org.chromium.Chromium is to be installed (which in practice it
  always is) then since its extension org.chromium.Chromium.Codecs has
  autodownload enabled (or strictly speaking has no-autodownload
  disabled) and is not masked by the 'exclude' list in the image builder
  config, it will be automatically installed by Flatpak while installing
  Chromium.

- Similarly, since all modern runtimes have an extension point for
  org.freedesktop.Platform.openh264 with autodownload enabled, since it
  is not excluded it will be installed automatically by Flatpak.

Listing them explicitly is actually not harmless at present because openh264 is
branched. Currently-released runtime versions use
runtime/org.freedesktop.Platform.openh264//2.2.0; but 2.4.1 was released
yesterday. If no branch is specified for a ref to be installed,
eibflatpak.FlatpakRemote.match() will pick the lexicographically highest
branch. So 2.4.1 is to be installed even though no runtime uses it, in
addition to the 2.2.0 version that released runtimes use.

And 2.4.1 is not installable due to
https://gitlab.com/freedesktop-sdk/openh264-extension/-/issues/19 so
the image build fails.

https://phabricator.endlessm.com/T35203
