### PR TITLE
Fix dpkg queries

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -132,6 +132,7 @@ hooks_add =
   70-flatpak-appstream-catalog
   70-flatpak-manifest
   70-ostree-manifest
+  70-packages-manifest
   80-ldconfig-aux-cache.chroot
 
 # Gzip compression by default (valid choices: gz or xz)

--- a/helpers/packages-manifest
+++ b/helpers/packages-manifest
@@ -12,7 +12,7 @@ apt_pkg.init()
 
 # Use the dpkg status file from the ostree deployment
 dpkg_status = os.path.join(os.environ['OSTREE_DEPLOYMENT'],
-                           'var/lib/dpkg/status')
+                           'usr/share/dpkg/database/status')
 apt_pkg.config.set('Dir::State::status', dpkg_status)
 
 # Open an apt Cache and output data for each installed package

--- a/hooks/image/70-packages-manifest
+++ b/hooks/image/70-packages-manifest
@@ -35,5 +35,9 @@ for pkg in sorted(cache):
         'size': pkg.installed.installed_size,
     }
 
-# Print out the json
-print(json.dumps(data, sort_keys=True))
+# Now write out the json to a fragment
+manifestdir = os.environ['EIB_MANIFESTDIR']
+manifest_path = os.path.join(manifestdir, 'packages.json')
+print('Writing packages manifest info to', manifest_path)
+with open(manifest_path, 'w') as manifest:
+    json.dump(data, manifest, sort_keys=True)

--- a/stages/eib_image
+++ b/stages/eib_image
@@ -161,12 +161,6 @@ dpkgdir="${OSTREE_DEPLOYMENT}"/usr/share/dpkg/database
 packageinfo="${EIB_TMPDIR}"/packages.txt
 dpkg-query -W --admindir="${dpkgdir}" > "${packageinfo}"
 
-# Add package info to manifest using helper. This needs to be run here
-# rather than in an image hook because the dpkg database will be masked
-# by the OS /var mount.
-pkg_manifest="${EIB_MANIFESTDIR}"/packages.json
-"${EIB_HELPERSDIR}"/packages-manifest > "${pkg_manifest}"
-
 run_hooks content "${OSTREE_DEPLOYMENT}"
 
 create_image() {

--- a/stages/eib_image
+++ b/stages/eib_image
@@ -155,8 +155,9 @@ if [[ "${EIB_IMAGE_SDBOOT}" = "true" ]]; then
   unset sdboot_esp_img_loop
 fi
 
-# Output package list using the dpkg database from the deployment's /var
-dpkgdir="${OSTREE_DEPLOYMENT}"/var/lib/dpkg
+# Output package list using the dpkg database from the deployment's
+# immutable copy in /usr/share/dpkg/database.
+dpkgdir="${OSTREE_DEPLOYMENT}"/usr/share/dpkg/database
 packageinfo="${EIB_TMPDIR}"/packages.txt
 dpkg-query -W --admindir="${dpkgdir}" > "${packageinfo}"
 


### PR DESCRIPTION
The ostree commits now ship with an empty `/var`, which means that `/var/lib/dpkg/status` doesn't exist. Use `/usr/share/dpkg/database` instead, which is what `/var/lib/dpkg` is a symlink to at runtime.

https://phabricator.endlessm.com/T35244