### PR TITLE
defaults: Add Image Viewer

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -471,6 +471,7 @@ apps_add_mandatory =
   org.gnome.Contacts
   org.gnome.Epiphany
   org.gnome.FileRoller
+  org.gnome.Loupe
   org.gnome.Totem
   org.gnome.Shotwell
   org.gnome.font-viewer


### PR DESCRIPTION
Image Viewer (codenamed Loupe) is a the new core image viewer app. Pairs with https://github.com/endlessm/eos-meta/pull/766.

https://phabricator.endlessm.com/T34908