### PR TITLE
defaults: Remove File Roller

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -471,7 +471,6 @@ apps_add_mandatory =
   org.gnome.Calculator
   org.gnome.Contacts
   org.gnome.Epiphany
-  org.gnome.FileRoller
   org.gnome.Loupe
   org.gnome.Totem
   org.gnome.Shotwell


### PR DESCRIPTION
Files (Nautilus) has built-in archive handling, now, so we don't need to include File Roller.

https://phabricator.endlessm.com/T35285