### PR TITLE
config: Update Decibels app ID

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -466,10 +466,10 @@ apps_add_mandatory =
 [flatpak-remote-flathub]
 repo_file = https://dl.flathub.org/repo/flathub.flatpakrepo
 apps_add_mandatory =
-  com.vixalien.decibels
   org.chromium.Chromium
   org.gnome.Calculator
   org.gnome.Contacts
+  org.gnome.Decibels
   org.gnome.Epiphany
   org.gnome.Loupe
   org.gnome.Totem


### PR DESCRIPTION
`com.vixalien.decibels` is now marked EOL since Flathub has added `org.gnome.Decibels`.

https://phabricator.endlessm.com/T32696