### PR TITLE
Support QEMU qcow2 image format

### DIFF
--- a/config/arch/amd64.ini
+++ b/config/arch/amd64.ini
@@ -10,6 +10,5 @@ packages_add =
   grub2
   mtools
   squashfs-tools
-  qemu-utils
   xorriso
   zip

--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -88,6 +88,7 @@ packages_add =
   python3-gi
   python3-requests
   python3-venv
+  qemu-utils
   rsync
   udev
   util-linux
@@ -147,10 +148,13 @@ boot_zip = true
 # Don't build ISOs by default
 iso = false
 
-# Don't build VM images by default
+# Don't build OVF VM images by default
 # This setting only works for arch=amd64, for all other values this is a no-op
 # (please also add the comment above to anywhere 'vm_image' is changed)
 vm_image = false
+
+# Don't build QEMU qcow2 images by default
+qcow2 = false
 
 # GPG private key ID for signing images. If this is left blank, detached
 # signatures will not be created.

--- a/config/product-personality/eos-base.ini
+++ b/config/product-personality/eos-base.ini
@@ -11,6 +11,9 @@ compression = xz
 # This setting only works for arch=amd64, for all other values this is a no-op
 vm_image = true
 
+# Build QEMU qcow2 image
+qcow2 = true
+
 [iso]
 # The capacity of a single-later DVD+R, which is the smallest
 # commonly-available writeable format according to

--- a/stages/eib_image
+++ b/stages/eib_image
@@ -597,6 +597,27 @@ EOF
     "${EIB_HELPERSDIR}"/create-vm-image "$(eib_outfile ovf.zip)" "${img}"
   fi
 
+  # Create qcow2 image if required.
+  if [ "${EIB_IMAGE_QCOW2}" = true ]; then
+    local qcow2
+
+    # Convert the raw image to qcow2 with compression (-c). This uses
+    # zlib, but it would be better to use zstd with -o
+    # compression_type=zstd. zstd support was added as an option in QEMU
+    # 5.1 in 2020, but we'd want to make sure zstd support was included
+    # in any distros/flatpaks we cared about.
+    qcow2=$(eib_outfile qcow2)
+    qemu-img convert -c -f raw -O qcow2 "${img}" "${qcow2}"
+
+    # Since the format is copy-on-write, we can grow it as much as we
+    # want without increasing the download size. Add 10 GiB.
+    qemu-img resize -f qcow2 "${qcow2}" +10G
+
+    stat -c "%s" "${qcow2}" > "${qcow2}.size"
+    sign_file "${qcow2}" &
+    checksum_file "${qcow2}" &
+  fi
+
   # Await signing and checksumming subprocesses
   wait
 


### PR DESCRIPTION
It's a nice format for loading in GNOME Boxes or any VM tool that uses QEMU. In particular, it's the native format used by GNOME Boxes.

https://phabricator.endlessm.com/T35332