### PR TITLE
image: Chown Kolibri and Endless Key data

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -131,6 +131,7 @@ hooks_add =
   62-kolibri-automatic-provision
   62-kolibri-options
   63-icon-grid
+  63-kolibri-chown.chroot
   70-flatpak-appstream-catalog
   70-flatpak-manifest
   70-ostree-manifest

--- a/hooks/image/53-ek-content-preload
+++ b/hooks/image/53-ek-content-preload
@@ -83,3 +83,9 @@ fi
 # unique Facility ID.
 # <https://kolibri.readthedocs.io/en/latest/install/provision.html#prepare-the-kolibri-folder-for-copying>
 (echo yes; echo yes) | kolibri manage --skip-update deprovision
+
+# Chown all the files to the kolibri user. This also happens at runtime
+# via the endless-key.conf tmpfiles.d configuration.
+kolibri_uid=$(ostree_uid kolibri)
+kolibri_gid=$(ostree_gid kolibri)
+chown -R "${kolibri_uid}:${kolibri_gid}" "${OSTREE_VAR}"/lib/endless-key

--- a/hooks/image/63-kolibri-chown.chroot
+++ b/hooks/image/63-kolibri-chown.chroot
@@ -1,0 +1,5 @@
+# Chown all Kolibri data files to the kolibri user. This also happens at
+# runtime via the eos-kolibri.conf tmpfiles.d configuration.
+if [ -d /var/lib/kolibri ]; then
+  chown -R kolibri:kolibri /var/lib/kolibri
+fi


### PR DESCRIPTION
tmpfiles.d configuration is provided for both that changes ownership to kolibri:kolibri for both at runtime. However, if there's an overlayfs on /var like there is when booting an ISO, all the files are copied to the upper tmpfs. That's likely to OOM the system when either is filled with preloaded data.

One possibility is to run the tmpfiles.d configuration here. For simplicity, we just run `chown` here. For Kolibri, a separate hook is added since the content generation is split across 3 hooks.

https://phabricator.endlessm.com/T35498

I haven't run this at all, but I believe it's correct.