### PR TITLE
Add validation for paths in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ with key suffixes as follows:
  * `_required`: `true` means that the key must be set
  * `_values`: the value, if set, must be within the space-separated list
    of values here
+ * `_type`: `path` means the value, if set, must be the path to a file which
+   exists
+ * `_type`: `paths` means the value, if set, must be a space-separated list of
+   path to files which exist
 
 Merged options
 --------------

--- a/config/schema.ini
+++ b/config/schema.ini
@@ -14,3 +14,10 @@ compression_values = gz
                      xz
 partition_table_values = gpt
                          dos
+branding_fbe_config_type = path
+icon_grid_type = paths
+initramfs_plymouth_watermark = path
+chromium_policies_managed = path
+chromium_policies_recommended = path
+settings = paths
+settings_locks = paths

--- a/config/schema.ini
+++ b/config/schema.ini
@@ -4,6 +4,9 @@
 #  _required = true means that the key must be set
 #  _values means the value, if set, must be within the space-separated list of
 #          values here
+#  _type = path means the value, if set, must be the path to a file which exists
+#  _type = paths means the value, if set, must be a space-separated list of
+#                path to files which exist
 
 [image]
 compression_required = true

--- a/run-build
+++ b/run-build
@@ -515,6 +515,26 @@ class ImageBuilder(object):
                 raise eib.ImageBuildError(
                     'Configuration key [%s] %s has invalid value: %s'
                     % (section, option, self.config[section][option]))
+        elif option.endswith('_type'):
+            real_option = option[:-len('_type')]
+            if real_option in self.config[section]:
+                real_value = self.config[section][real_option].strip()
+                if value == "path":
+                    paths = [real_value] if real_value else []
+                elif value == "paths":
+                    paths = real_value.split()
+                else:
+                    raise eib.ImageBuildError(
+                        f'Schema key [{section}] {option} has invalid value: '
+                        f'{value}'
+                    )
+
+                for path in paths:
+                    if not os.path.exists(path):
+                        raise eib.ImageBuildError(
+                            f'Configuration key [{section}] {real_option} refers to '
+                            f'nonexistent path: {path}'
+                        )
 
     def check_config(self):
         """Check loaded configuration against schema for validity."""


### PR DESCRIPTION
Previously, if a filename referred to in the configuration does not exist, that would only be discovered when the hook which uses that key runs, which may be minutes or hours into the build.

Add a way to specify in the schema that certain keys must be set to a single path to an extant file, or a list of paths to extant files.

Add `key_type = path(s)` annotations to the schema for all (I think) of the file-like `key`s used by hooks in this repo.

https://phabricator.endlessm.com/T35517