### PR TITLE
Hooks: Add hook to expose Endless Key launchers in app grid

### DIFF
--- a/hooks/image/54-ek-launchers
+++ b/hooks/image/54-ek-launchers
@@ -1,0 +1,10 @@
+# Expose Endless Key launchers in the app grid (once a specific content pack has been downloaded)
+
+mkdir -p "${OSTREE_DEPLOYMENT}/etc/systemd/user-environment-generators"
+cat <<- 'EOF' > "${OSTREE_DEPLOYMENT}/etc/systemd/user-environment-generators/62-endless-key.sh"
+	#!/bin/bash
+
+	XDG_DATA_DIRS="/var/lib/endless-key/data/content/xdg/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+	echo "XDG_DATA_DIRS=$XDG_DATA_DIRS"
+EOF
+chmod 755 "${OSTREE_DEPLOYMENT}/etc/systemd/user-environment-generators/62-endless-key.sh"


### PR DESCRIPTION
Is this the right idea? It sort of feels dirty to include a whole shell script here. And do I need to make it executable?

https://phabricator.endlessm.com/T35614