### PR TITLE
ImageConfigParser: Don't sort merged values

### DIFF
--- a/lib/eib.py
+++ b/lib/eib.py
@@ -242,25 +242,23 @@ class ImageConfigParser(configparser.ConfigParser):
                                  opt)
                     yield (section, opt)
             else:
-                add_vals = Counter()
+                values = Counter()
                 for opt in add_opts:
                     logger.debug('Adding %s %s values from %s', section,
                                  option, opt)
-                    add_vals.update(sect[opt].split())
+                    values.update(sect[opt].split())
                     yield (section, opt)
 
-                del_vals = Counter()
                 for opt in del_opts:
                     logger.debug('Removing %s %s values from %s', section,
                                  option, opt)
-                    del_vals.update(sect[opt].split())
+                    values.subtract(sect[opt].split())
                     yield (section, opt)
 
-                # Set the option to the difference of the counters.
+                # Set the option to the keys that have positive values.
                 # Merge the values together with newlines like they were
                 # in the original configuration.
-                vals = add_vals - del_vals
-                sect[option] = '\n'.join(sorted(vals.keys()))
+                sect[option] = '\n'.join(k for k, v in values.items() if v > 0)
 
     def copy(self):
         """Create a new instance from this one"""

--- a/tests/eib/test_image_config_parser.py
+++ b/tests/eib/test_image_config_parser.py
@@ -119,8 +119,8 @@ def test_merged_option(config):
 
     assert set(sect) == {'opt'}
 
-    # The values will be sorted and newline separated
-    assert sect['opt'] == 'baz\nfoo'
+    # The values will be newline separated in the order they appeared.
+    assert sect['opt'] == 'foo\nbaz'
 
     # Now that the merged option exists, it will override any further
     # add/del.
@@ -129,7 +129,7 @@ def test_merged_option(config):
     config.merge()
 
     assert set(sect) == {'opt'}
-    assert sect['opt'] == 'baz\nfoo'
+    assert sect['opt'] == 'foo\nbaz'
 
 
 def test_merged_option_interpolation(config):
@@ -277,7 +277,7 @@ def test_merged_files(tmp_path, config):
     config.merge()
 
     assert set(config['sect']) == {'opt'}
-    assert config['sect']['opt'] == 'baz\nfoo'
+    assert config['sect']['opt'] == 'foo\nbaz'
     assert set(config['sect-a']) == {'opt'}
     assert config['sect-a']['opt'] == ''
     assert set(config['sect-b']) == {'opt'}


### PR DESCRIPTION
The order of configuration values may be significant, so the parser should not sort them. To do that, use a single counter for add and del variants and emit the values that have positive counts without sorting. This relies on the Python dict stable order, which has been the case since Python 3.6.

I've done no real world testing of this. It should also be stated that the order you get is "first merged section wins", so it's not really reliable. For example:

```
[section]
# From product config
option_add_product = foo
# From local product config
option_add_local_product = bar
```

You'd get `foo\nbar` even though you might really prefer `bar\nfoo` from your local setting. With explicit sorting you'd always get the same values regardless of what order the unmerged options came in.