### PR TITLE
Match selected Endless Key content collections correctly

### DIFF
--- a/hooks/image/53-ek-content-preload
+++ b/hooks/image/53-ek-content-preload
@@ -17,8 +17,8 @@ all_collection_files="${OSTREE_VAR}"/lib/flatpak/app/org.endlessos.Key/current/a
 for collection_file in ${all_collection_files}; do
   # Check if the file basename stripped off of -0001.json is part of the list
   # of collections to be installed.
-  bn=$(basename ${collection_file})
-  if [[ "${EIB_ENDLESSKEY_COLLECTIONS}" =~ .*"${bn%-????.json}".* ]] ; then
+  bn=$(basename "${collection_file%-????.json}")
+  if [[ " ${EIB_ENDLESSKEY_COLLECTIONS} "  =~ [[:space:]]${bn}[[:space:]] ]] ; then
     selected_collection_files+=("${collection_file}")
     jq -r '.channels[].id' "${collection_file}" >> "${channels_file}"
   fi


### PR DESCRIPTION
EIB_ENDLESSKEY_COLLECTIONS is a whitespace (typically space or newline)-separated list of collection names. These are matched against collection filenames to determine what to fetch.

We have collection files named `extras-preload-0001.json` and `spanish-extras-preload-0001.json`. The intention is that if `[endlesskey] collections` contains `spanish-extras-preload` but not `extras-preload`, only the latter will be imported, not the former.

However, the logic that matched filenames against the configured array did not consider the case when one collection name is a substring of another. It would incorrectly match `extras-preload-0001.json` against `spanish-extras-preload` because the latter contains `extras-preload` as a substring.

Replace runs of whitespace in EIB_ENDLESSKEY_COLLECTIONS with colons, with an extra colon at the start and end of the resulting string. Then, surround the base collection name from each collection manifest path with colons in the same way, and check if this is a substring. This assumes that the colon does not appear in collection names: a rather safe assumption I think.

(The root cause of this bug is that shell scripts are not a suitable language for non-trivial logic. I tried to use Bash arrays but apparently Bash does not have a "contains" operator for arrays. I also considered using the ASCII unit separator character, U+001F, as the delimiter, which is even less likely to appear in collection names than a colon, but decided against it.)

https://phabricator.endlessm.com/T35668#1004203

(PR targeting eos6.0 so that I can test it. I'll rebase it to the closest common ancestor of eos6.0 and master to be merged directly into both if it works.)