### PR TITLE
Populate .desktop files for Endless Key channels

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -300,6 +300,12 @@ regular_users_can_manage_content = false
 # pre-release not on PyPI.
 kolibri_pkgspec = https://github.com/learningequality/kolibri/releases/download/v0.16.0-beta6/kolibri-0.16.0b6-py2.py3-none-any.whl
 
+# Kolibri xdg desktop file plugin to use when preloading channels. Out of the
+# box these desktop files are not used for Endless Key, but some OS images may
+# add them to the search path, so we should ensure they are pregenerated in the
+# OS image.
+kolibri_app_desktop_xdg_plugin_version = 1.3.0
+
 # Which Endless Key collections to preload in the image.
 # Must match the name of one of the collections shipped with the Endless Key
 # (ex. artist, explorer, spanish etc).

--- a/hooks/image/53-ek-content-preload
+++ b/hooks/image/53-ek-content-preload
@@ -37,11 +37,13 @@ venv_dir="${EIB_TMPDIR}/kolibri-content-venv"
 python3 -m venv ${venv_dir}
 source ${venv_dir}/bin/activate
 pip install "${EIB_ENDLESSKEY_KOLIBRI_PKGSPEC}"
+pip install kolibri-app-desktop-xdg-plugin==${EIB_ENDLESSKEY_KOLIBRI_APP_DESKTOP_XDG_PLUGIN_VERSION}
 
 # Setup the homedir before setting any environment variables so they
 # don't persist into the options file.
 export KOLIBRI_HOME="${OSTREE_VAR}"/lib/endless-key/data
 mkdir -p "${KOLIBRI_HOME}"
+kolibri plugin enable kolibri_app_desktop_xdg_plugin
 kolibri configure setup
 
 # Use a separate content URL if configured.
@@ -49,6 +51,11 @@ if [ -n "${EIB_KOLIBRI_CENTRAL_CONTENT_BASE_URL}" ]; then
   KOLIBRI_CENTRAL_CONTENT_BASE_URL="${EIB_KOLIBRI_CENTRAL_CONTENT_BASE_URL}"
   export KOLIBRI_CENTRAL_CONTENT_BASE_URL
 fi
+
+# kolibri-app-desktop-xdg-plugin uses FLATPAK_ID to determine how to name the
+# launchers it creates. This is set by Flatpak when running the app, but we are
+# not running kolibri from within the Endless Key Flatpak here.
+export FLATPAK_ID=org.endlessos.Key
 
 # Import all channel metadata and thumbnails for all channels
 for channel in $all_channels; do
@@ -83,6 +90,16 @@ fi
 # unique Facility ID.
 # <https://kolibri.readthedocs.io/en/latest/install/provision.html#prepare-the-kolibri-folder-for-copying>
 (echo yes; echo yes) | kolibri manage --skip-update deprovision
+
+# Hack the .desktop files to work around them being generated differently when
+# the xdg plugin is running in the Flatpak, which it is not here.
+for desktop_file in "${OSTREE_VAR}"/lib/endless-key/data/content/xdg/share/applications/*.desktop; do
+    sed -i -e 's/x-kolibri-dispatch:/x-endless-key-dispatch:/g' "${desktop_file}"
+    desktop-file-edit \
+        --set-key=TryExec \
+        --set-value=/var/lib/flatpak/app/org.endlessos.Key/current/active/files/bin/kolibri-gnome \
+        "${desktop_file}"
+done
 
 # Chown all the files to the kolibri user. This also happens at runtime
 # via the endless-key.conf tmpfiles.d configuration.


### PR DESCRIPTION
Endless Key was designed to be used via a single entrypoint, rather than per-channel launchers as we have for Kolibri on Endless OS. However, a partner have specifically requested per-channel launchers coupled with the Endless Key interface & content. To support them, Endless Key bundles the same xdg plugin for Kolibri as for the kolibri-gnome app, which generates .desktop files etc. into `/var/lib/endless-key/data/content/xdg/share/`. Then in this partner's OS image, we drop a file into /etc/systemd/user-environment-generators to add this directory to XDG_DATA_DIRS, just like the file we ship in /usr/systemd/user-environment-generators for Kolibri.

However, previously that path was not pre-populated in the image builder for Endless Key content that is preloaded into the image. This is fundamentally because the image builder doesn't use the copy of Kolibri that is inside the Endless Key Flatpak to preload content: it sets up its own temporary virtualenv with Kolibri inside and uses that. But the xdg plugin was not installed to that environment.

In order to generate .desktop files at image build time, install kolibri-app-desktop-xdg-plugin into the temporary venv, and enable it. This matches the corresponding logic in 60-kolibri-content. Unfortunately this is not sufficient:

1. The generated .desktop files are named based on the FLATPAK_ID environment variable, defaulting to org.learningequality.Kolibri if it is not set. Since we are not running a Flatpak, we need to set it by hand.

2. The URI scheme used in the .desktop files is based on a variable in the kolibri_app.config module, which is installed by kolibri-gnome-app and derives its contents from options passed to meson setup. Again, since we are not using the Flatpak build, this module does not exist. Rather than building & installing kolibri-gnome, or installing a fake version of this module that contains the fields we need, munge the desktop files with `sed`.

3. The .desktop files generated by the Flatpak include a TryExec= line, which is there to ensure that the launchers are not shown if the Flatpak is removed from the system. It is derived from the contents of the /.flatpak-info file, though with the Flatpak commit ID replaced with `active`. Since we are not using the Flatpak build, this file does not exist and this logic is not triggered. Use desktop-file-edit to add the field by hand.

I'm not exactly delighted with this patch but it does work. Longer term I would hope that we can either retire Endless Key in favour of generic Kolibri, and/or make the image builder use the appropriate Flatpak rather than installing its own copy of Kolibri, which has other downsides.

https://phabricator.endlessm.com/T35760
https://phabricator.endlessm.com/T35761