### PR TITLE
Remove eos-dir-mode-700 hook

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -121,7 +121,6 @@ hooks_add =
   50-update-done-stamp
   50-reclaim-swap-stamp
   50-gnome-software-cache
-  50-eos-dir-mode-700
   50-xkb-layout.chroot
   53-ek-content-preload
   60-dconf-prepare

--- a/hooks/image/50-eos-dir-mode-700
+++ b/hooks/image/50-eos-dir-mode-700
@@ -1,6 +1,0 @@
-# Create stamp file to indicate that
-# eos-boot-helper/eos-fix-home-dir-permissions.service does not need to run on
-# new images.
-
-mkdir -p ${OSTREE_VAR}/lib/misc
-touch    ${OSTREE_VAR}/lib/misc/eos-dir-mode-700


### PR DESCRIPTION
The purpose of this hook was to write a stamp file to prevent a migration task being run on new systems.

The migration task in question was removed in Endless OS 3.5 back in 2018.

https://github.com/endlessm/eos-boot-helper/commit/ae137ab6dd2203422ccecc62ca58c1369f602079 https://phabricator.endlessm.com/T22548