### PR TITLE
tests: Replace GitHub Actions ubuntu-20.04 runner with 24.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
           - ubuntu-22.04
+          - ubuntu-24.04
     runs-on: ${{ matrix.os }}
     name: Run tests
     steps:


### PR DESCRIPTION
GitHub announced:
The Ubuntu 20.04 Actions runner image will begin deprecation on 2025-02-01 and will be fully unsupported by 2025-04-15. [1]

So, bump the runner to ubuntu-latest directly.

[1]: https://github.com/actions/runner-images/issues/11101