### PR TITLE
config: ES: Migrate some flatpak apps and Kolibri channels to eosimpact-es.ini

### DIFF
--- a/config/personality/es.ini
+++ b/config/personality/es.ini
@@ -23,7 +23,6 @@ apps_add =
   com.endlessm.dinosaurs.es
   com.endlessm.disabilities.es
   com.endlessm.encyclopedia.es
-  com.endlessm.farming.es_GT
   com.endlessm.geography.es
   com.endlessm.handicrafts.es
   com.endlessm.health.es
@@ -32,143 +31,20 @@ apps_add =
   com.endlessm.howto.es
   com.endlessm.maternity.es
   com.endlessm.math.es
-  com.endlessm.microenterprises.es_GT
   com.endlessm.myths.es
   com.endlessm.physics.es
-  com.endlessm.programming
   com.endlessm.programming_guide.es
   com.endlessm.soccer.es
-  com.endlessm.social_enterprises.es_GT
   com.endlessm.socialsciences.es
   com.endlessm.travel.es
-  com.endlessm.video_animal_kingdom
-  com.endlessm.vroom.es
   com.endlessm.water_and_sanitation.es
   com.endlessm.world_literature.es
-  com.endlessnetwork.arduinoprojects
-  com.endlessnetwork.blendertutorials
-  com.endlessnetwork.csstutorials
-  com.endlessnetwork.htmltutorials
-  com.endlessnetwork.sciencesnacks
 
 [flatpak-remote-flathub]
 apps_add =
   ar.com.pilas_engine.App
-  as.may.moat
-  com.github.carlos157oliveira.Calculus
-  com.mardojai.DiccionarioLengua
-  net.ankiweb.Anki
-  org.eclipse.Java
-  org.freecad.FreeCAD
-  org.gnome.gbrainy
-  org.kde.kalgebra
-  org.kde.kblocks
-  org.kde.kbruch
-  org.kde.kgeography
-  org.kde.khangman
-  org.kde.kstars
-  org.learningequality.Kolibri
-  org.moneymanagerex.MMEX
-  org.qgis.qgis
-  org.stellarium.Stellarium
-  org.sugarlabs.TypingTurtle
 
 [endlesskey]
 collections_add =
   spanish
   spanish-extras
-
-[kolibri]
-automatic_provision = true
-install_channels =
-  # Simulaciones interactivas PhET [533]
-  8fa678af1dd05329bf3218c549b84996
-  # Sikana (Español) [40]
-  30c71c99c42c57d181e8aeafd2e15e5f
-  # Ciencia NASA [12]
-  da53f90b1be25752a04682bbc353659f
-  # Khan Academy (Español) [87]
-  c1f2b7e6ac9f56a2bb44fa7a48b66dce
-
-[kolibri-30c71c99c42c57d181e8aeafd2e15e5f]
-include_node_ids =
-  # Salud / Aprende a salvar una vida / Conocimientos básicos / Botiquín de emergencia [video]
-  38dc0038fdad501da670ed71274b4bb1
-  # Salud / Aprende a salvar una vida / Conocimientos básicos / Botiquín de emergencia [document]
-  c28baeb64adb54309d8e1e53443b5769
-  # Salud / Aprende a salvar una vida / Conocimientos básicos / Cómo llamar a los servicios de emergencia [video]
-  529a3ae25f9e5f4293490e2630c3e4f6
-  # Salud / Aprende a salvar una vida / Conocimientos básicos / Cómo llamar a los servicios de emergencia [document]
-  e44df7ef6e525003ae287b8a8291ccc2
-  # Salud / Aprende a salvar una vida / Conocimientos básicos / Cómo prevenir los accidentes de la vida cotidiana [video]
-  8c38aa3d48ce5a88831d992bb6ab3bdc
-  # Salud / Aprende a salvar una vida / Conocimientos básicos / Cómo prevenir los accidentes de la vida cotidiana [document]
-  7b98a4aca8d05ff18f23cdff76d8b77d
-  # Salud / Aprende a salvar una vida / Conocimientos básicos / Primeros auxilios :  Posición lateral de seguridad [video]
-  24d55c34a0735bb2ae6c1eb296cd00d3
-  # Salud / Aprende a salvar una vida / Conocimientos básicos / Primeros auxilios :  Posición lateral de seguridad [document]
-  23edc5ba956b5b6d9d3ae7448bbad13d
-  # Salud / Aprende a salvar una vida / Conocimientos básicos / Primeros auxilios : Cómo utilizar un desfibrilador [document]
-  dda8b214bec255a398dde4f8fee7860b
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios : Crisis convulsiva [video]
-  2e5bdf6523a25cc2a6e2e4dce9351bb4
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios : Crisis convulsiva [document]
-  d82c410639405cd6a06daf1b7a9ca546
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios : Traumatismo craneal y de la columna vertebral [video]
-  45996c6efde05679afb74ae1dded3805
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios : Traumatismo craneal y de la columna vertebral [document]
-  ef63e295aa2f5035a863f62d78875181
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios: Herida leve [video]
-  123fe0f584b95e508e14b80bda2377f7
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios: Herida leve [document]
-  5a63b904389458b8b366c2955e4b2477
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios : Herida grave [document]
-  95e43908341052a18d291687ea2312a3
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios : Hematoma [video]
-  3527fa87085a5688afd8a1424076a13d
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios : Hematoma [document]
-  72044a552a1f5b4d97923ec129532533
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios : Picadura de garrapata [video]
-  0584f5dc75e35c148a525552aaee7c17
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios : Picadura de garrapata [document]
-  f525e8bf88da526b94aecc782756ce23
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios : Mordedura de serpiente [video]
-  96322b64272b53cead7bfdd186c6d70a
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios : Mordedura de serpiente [document]
-  89e5ba33db33503b9cc81c52108e4ee6
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios : Hemorragia [video]
-  c52a6e4fa9385866b6e42c3c54fc708d
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios : Hemorragia [document]
-  e36f43e22218534f830bfc6d6354ef3c
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios : Sangrado de nariz [video]
-  bb170b868bb754ca906ab5a1bd027226
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios : Sangrado de nariz [document]
-  a73da2996b3a54968d0d341b7bf22a90
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios : Miembro seccionado [video]
-  bb252814a945503dbc424791220182c2
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios : Miembro seccionado [document]
-  e6244ea7d92253e7adc6d7c28a58c69d
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios : Intoxicación de monóxido de carbono [video]
-  91f86dc917ea51979049ee185c9b361c
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios : Intoxicación de monóxido de carbono [document]
-  18d04bb98f48504a9b8f58131879792f
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios : Intoxicación alimentaria [video]
-  07d9bb78c5b75c12b5f19049b5a947b6
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios : Intoxicación alimentaria [document]
-  8bd0b20ac51a5d64b34cb1671c2708a4
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios : Intoxicación química [video]
-  48e6fa3e6db45ccda90b12985062eea4
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios : Intoxicación química [document]
-  4405598934f05b31881bb99d98c4a7d2
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios : Atragantamiento de un niño [video]
-  d0bae51d4302578886839cb0eeff975f
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios : Atragantamiento de un niño [document]
-  3d75c5abf63a5054b697c3304bc26344
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios : Crisis diabética y desmayo [video]
-  e4658d7ce7145ef6908091cb0b9f280d
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios : Crisis diabética y desmayo [document]
-  58caee429a855d77a140ad8e8eaf15b3
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios : Picadura de medusa [video]
-  a01ede93e4485f9a8cc78e0da34f742e
-  # Salud / Aprende a salvar una vida / Aprende las técnicas de primeros auxilios / Primeros auxilios : Picadura de medusa [document]
-  cfa73dbf33d956298e0d8a47db0e6979


### PR DESCRIPTION
These content flatpak apps and Kolibri channels are added by PR: "config: ES: Add more apps into generic EOS ES images" [1]. The plenty of content is good, but it also makes image become heavy to 57.1 GB (compressed). Downloading takes much more time. Besides, we also want to differentiate our impact images from common images. Although, the users still can download the flatpak apps and Kolibri channels by themselves actually.

So, drop the modification from the PR "config: ES: Add more apps into generic EOS ES images" for the migration.

This reverts commits d2a56d44cf11 ("config: ES: Add more apps into generic EOS ES images") and e345f8653e48 ("config: ES: Add Kolibri channels into ES").

[1]: https://github.com/endlessm/eos-image-builder/pull/174

https://phabricator.endlessm.com/T35862