### PR TITLE
eib-chroot: Use bwrap for chroot

### DIFF
--- a/helpers/eib-chroot
+++ b/helpers/eib-chroot
@@ -70,4 +70,6 @@ for name in ${!EIB_*} ; do
 done
 
 # Run the real chroot
-exec env - "${env_vars[@]}" "$(type -P chroot)" "$@"
+new_root=${1:?new root is required}
+shift
+exec env - "${env_vars[@]}" "$(type -P bwrap)" --dev-bind "$new_root" / "$@"


### PR DESCRIPTION
Changing root with nested chroot command makes flatpak fail to convert FlatpakExports to bwrap arguments in the hook script 50-flatpak.chroot:
```
(process:5470): flatpak-DEBUG: 12:04:39.307: Converting FlatpakExports to bwrap arguments...
(process:5470): flatpak-DEBUG: 12:04:39.307: D-Bus proxy not needed
flatpak-INFO: 12:04:39.307: Running /app/bin/apply_extra
bwrap: No permissions to creating new namespace, likely because the kernel does not allow non-privileged user namespaces. On e.g. debian this can be enabled with 'sysctl kernel.unprivileged_userns_clone=1'.
```
So, use bwrap to change root into the sandbox to avoid permission issue.

Part-of: https://github.com/endlessm/eos-build-meta/issues/102