### PR TITLE
Run systemd-tmpfiles in the ostree checkout

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -63,6 +63,7 @@ hooks_add =
 # Merged customization hooks to run.
 hooks_add =
   10-systemd-sysusers.chroot
+  10-systemd-tmpfiles.chroot
   50-branding-background
   50-branding-fbe
   50-flatpak.chroot

--- a/hooks/image/10-systemd-tmpfiles.chroot
+++ b/hooks/image/10-systemd-tmpfiles.chroot
@@ -1,0 +1,2 @@
+# Create temporary directories.
+systemd-tmpfiles --create --exclude-prefix=/srv


### PR DESCRIPTION
This is to fix an issue during the 50-flatpak image hook, which would fail at the appstream update with this:

    gi.repository.GLib.GError: g-io-error-quark: While pulling appstream2/x86_64 from remote flathub: open(O_TMPFILE): No such file or directory (1)

The root cause being a lack of `/var/tmp` in the ostree checkout.

It's surprising that things worked as well as they did until now, and perhaps is due to the ostree containing more things in `/var/` than it should.