### PR TITLE
defaults: Preinstall Threadbare

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -470,6 +470,7 @@ apps_add =
   io.thp.numptyphysics
   org.audacityteam.Audacity
   org.blender.Blender
+  org.endlessaccess.threadbare
   org.endlessos.Key
   org.gimp.GIMP
   org.gnome.Cheese


### PR DESCRIPTION
Per a [discussion on Slack](https://endlessaccess.slack.com/archives/C08F4Q0BPNV/p1757116600317809) (sorry that's not accessible), we already preinstall other education-focused games as well as Godot Engine, Asperite, so it makes sense to include Threadbare as well.

This will help Endless OS images support our game-making programs out of the box in the future.

https://app.asana.com/1/1203676861188277/project/1211059977498055/task/1211265094971560