### PR TITLE
README: Document using bubblewrap as the sandboxing tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Setup
 
 Known to work on Debian Buster (10) and newer. Required packages:
 
+ * bubblewrap
  * ostree
  * python3
 


### PR DESCRIPTION
The eos-image-builder uses bubblewrap as the sandboxing tool after commit eb9fefb39b38 ("eib-chroot: Use bwrap for chroot").

Part-of: https://github.com/endlessm/eos-build-meta/issues/126