### PR TITLE
buildscript: Install awscli

### DIFF
--- a/buildscript
+++ b/buildscript
@@ -39,6 +39,7 @@ export GIT_SSH="${EIB_HELPERSDIR}/git-ssh"
 
 # Tell aws tools to use credentials in sysconfdir
 export AWS_SHARED_CREDENTIALS_FILE="${EIB_SYSCONFDIR}/aws-credentials"
+. ${EIB_HELPERSDIR}/install-awscli
 
 . "${EIB_BASELIB}"
 

--- a/helpers/install-awscli
+++ b/helpers/install-awscli
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Follow document "Installing or updating to the latest version of the AWS CLI"
+# https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
+pushd "$(mktemp -d)"
+curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"
+unzip awscliv2.zip
+./aws/install --bin-dir /usr/bin
+
+# Clean up source
+popd
+rm -r "$OLDPWD"
+
+# Show installed awscli version
+aws --version


### PR DESCRIPTION
Introduce helpers/install-awscli to install awscli into the build environment. The eos-image-builder cannot publish built images to AWS s3 without awscli.

In the past (EOS 6), awscli can be installed from Debian packages repository. However, since EOS 7 based on GNOME OS, there is no package manager system. So, install awscli execution binary by following the AWS document "Installing or updating to the latest version of the AWS CLI".

Fixes: https://github.com/endlessm/eos-build-meta/issues/137