### PR TITLE
helpers/install-awscli: Avoid 8000 lines of messages from `unzip`

### DIFF
--- a/helpers/install-awscli
+++ b/helpers/install-awscli
@@ -4,7 +4,7 @@
 # https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
 pushd "$(mktemp -d)"
 curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"
-unzip awscliv2.zip
+unzip -q awscliv2.zip
 ./aws/install --bin-dir /usr/bin
 
 # Clean up source


### PR DESCRIPTION
By default `unzip` lists every file it unpacks, which produces over 8000 lines of log output.  Add `-q` to avoid that.