### PR TITLE
Exclude codecs-extra extension

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -550,6 +550,7 @@ exclude_add =
   net.mediaarea.QCTools
   org.audacityteam.Audacity.Codecs
   org.blender.Blender.Codecs
+  org.freedesktop.Platform.codecs-extra
   org.freedesktop.Platform.ffmpeg
   org.freedesktop.Platform.ffmpeg-full
   org.freedesktop.Platform.ffmpeg_full.i386


### PR DESCRIPTION
This is freedesktop-sdk 25.08's successor to ffmpeg-full, which also includes encumbered HEIC support for libheif (which is now part of the runtime).