### PR TITLE
arm64: Fix eosimpact-en image build failures

### DIFF
--- a/config/arch/arm64.ini
+++ b/config/arch/arm64.ini
@@ -18,8 +18,10 @@ apps_del =
   com.endlessm.finance
   com.endlessm.resume
 
+# Following flatpak apps do not support aarch64
 [flatpak-remote-flathub]
 apps_del =
+  ar.com.tuxguitar.TuxGuitar
   cc.arduino.IDE2
   com.endlessnetwork.aqueducts
   com.endlessnetwork.blendertutorials
@@ -32,4 +34,12 @@ apps_del =
   com.endlessnetwork.tankwarriors
   com.endlessnetwork.whitehouse
   com.orama_interactive.Pixelorama
+  com.gamestarmechanic.gamestarmechanic
+  com.github.scrivanolabs.scrivano
+  com.lixgame.Lix
+  com.unity.UnityHub
+  de.bforartists.Bforartists
   org.blender.Blender
+  org.freecadweb.FreeCAD
+  org.scilab.Scilab
+  ro.go.hmlendea.DL-Desktop

--- a/stages/eib_image
+++ b/stages/eib_image
@@ -277,7 +277,6 @@ create_image() {
         bios_boot_loop=${img_loop}p2
         root_loop=${img_loop}p3
       fi
-      ext4_opts="dir_index,^huge_file"
       ESP="${ROOT}"/boot/efi
       if [[ "${EIB_IMAGE_SDBOOT}" = "true" ]]; then
         dd conv=notrunc if="${sdboot_esp_img}" of="${esp_loop}" bs=1M
@@ -286,8 +285,6 @@ create_image() {
       fi
       ;;
     *)
-      # On ARM disable 64bit ext4 option
-      ext4_opts="dir_index,^huge_file,^64bit"
       if [ "${EIB_PLATFORM:0:3}" == "rpi" ]; then
         boot_loop=${img_loop}p1
         root_loop=${img_loop}p2
@@ -297,7 +294,7 @@ create_image() {
       ;;
   esac
 
-  mke2fs -t ext4 -O ${ext4_opts} -m1 -L ostree -T default ${root_loop}
+  mke2fs -t ext4 -O dir_index,^huge_file -m1 -L ostree -T default ${root_loop}
   mkdir -p "${ROOT}"
   eib_mount ${root_loop} "${ROOT}"
 

--- a/stages/eib_image
+++ b/stages/eib_image
@@ -294,7 +294,7 @@ create_image() {
       ;;
   esac
 
-  mke2fs -t ext4 -O dir_index,^huge_file -m1 -L ostree -T default ${root_loop}
+  mke2fs -t ext4 -O dir_index -m1 -L ostree -T default ${root_loop}
   mkdir -p "${ROOT}"
   eib_mount ${root_loop} "${ROOT}"
 


### PR DESCRIPTION
* Here lists more Flathub apps gathered from endless-image-config, but they do not support aarch64. This avoids install the apps on arm64 images.
* EOS builds image with offline content. So, the image might be larger than 100 GB. Enable ext4's 64bit option to support larger storage.

https://app.asana.com/1/1203676861188277/project/1211949321657103/task/1212671431325376
https://app.asana.com/1/1203676861188277/project/1211949321657103/task/1212760656967809