### PR TITLE
config: Drop com.endlessm.photos

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -451,7 +451,6 @@ apps_add_mandatory =
   org.libreoffice.LibreOffice
 apps_add =
   cc.arduino.IDE2
-  com.endlessm.photos
   com.endlessnetwork.aqueducts
   com.endlessnetwork.dragonsapprentice
   com.endlessnetwork.fablemaker

--- a/config/local.ini.example
+++ b/config/local.ini.example
@@ -48,4 +48,4 @@ apps =
 # Completely override the set of installed Flathub apps. See documentation
 # for eos-apps above.
 apps =
-  com.endlessm.photos
+  org.gnome.Loupe


### PR DESCRIPTION
The com.endlessm.photos is going to be EOL on Flathub [1] and has not been maintained for a long time. So, drop it from the default apps. Change the config example accordingly, too.

[1]: https://github.com/flathub/com.endlessm.photos/issues/12