### PR TITLE
config: Drop EOL Endless Studio apps on Flathub

### DIFF
--- a/config/arch/arm64.ini
+++ b/config/arch/arm64.ini
@@ -19,16 +19,7 @@ apps_del =
 apps_del =
   ar.com.tuxguitar.TuxGuitar
   cc.arduino.IDE2
-  com.endlessnetwork.aqueducts
   com.endlessnetwork.blendertutorials
-  com.endlessnetwork.dragonsapprentice
-  com.endlessnetwork.fablemaker
-  com.endlessnetwork.frogsquash
-  com.endlessnetwork.MidnightmareTeddy
-  com.endlessnetwork.missilemath
-  com.endlessnetwork.passage
-  com.endlessnetwork.tankwarriors
-  com.endlessnetwork.whitehouse
   com.orama_interactive.Pixelorama
   com.gamestarmechanic.gamestarmechanic
   com.github.scrivanolabs.scrivano

--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -451,15 +451,6 @@ apps_add_mandatory =
   org.libreoffice.LibreOffice
 apps_add =
   cc.arduino.IDE2
-  com.endlessnetwork.aqueducts
-  com.endlessnetwork.dragonsapprentice
-  com.endlessnetwork.fablemaker
-  com.endlessnetwork.frogsquash
-  com.endlessnetwork.MidnightmareTeddy
-  com.endlessnetwork.missilemath
-  com.endlessnetwork.passage
-  com.endlessnetwork.tankwarriors
-  com.endlessnetwork.whitehouse
   com.orama_interactive.Pixelorama
   com.tux4kids.tuxmath
   com.tux4kids.tuxtype


### PR DESCRIPTION
Endless Studio apps from Flathub have not been maintained for a long time and are going to be EOL. So, drop EOL Endless Studio apps.

https://app.asana.com/1/1203676861188277/project/1211949321657103/task/1215522633933682