### PR TITLE
eib_image: Introduce a new hook diskimage

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -376,6 +376,10 @@ dev_pull_url = ${dev_pull_repo_url}/${repo}
 # Enable P2P OS updates
 enable_p2p_updates = true
 
+[diskimage]
+# Merged customization hooks to run.
+hooks_add =
+
 [manifest]
 # Merged customization hooks to run.
 hooks_add =

--- a/lib/eib.py
+++ b/lib/eib.py
@@ -116,6 +116,7 @@ class ImageConfigParser(configparser.ConfigParser):
         ('buildroot', 'packages'),
         ('check', 'hooks'),
         ('content', 'hooks'),
+        ('diskimage', 'hooks'),
         ('endlesskey', 'collections'),
         ('error', 'hooks'),
         ('flatpak', 'locales'),

--- a/stages/eib_image
+++ b/stages/eib_image
@@ -557,6 +557,8 @@ EOF
       ;;
   esac
 
+  run_hooks diskimage "${ROOT}"
+
   eib_fix_boot_checksum "${img_loop}" "${DEPLOY}"
 
   # Read OS version from ostree deployment before we unmount it


### PR DESCRIPTION
Introduce a new hook diskimage which will be executed before finalize a new created image. This gives the chance for disk image level modificaiton within the diskimage hooks scripts in the future.

https://app.asana.com/1/1203676861188277/project/1211949321657103/task/1216023699715178